### PR TITLE
Fix Enum Order Compile Error

### DIFF
--- a/src/protobuf.zig
+++ b/src/protobuf.zig
@@ -87,9 +87,9 @@ pub const FieldType = union(FieldTypeTag) {
     Varint: VarintType,
     FixedInt: FixedSize,
     SubMessage,
-    String,
     List: ListType,
     PackedList: ListType,
+    String,
     OneOf: type,
 
     /// returns the wire type of a field. see https://developers.google.com/protocol-buffers/docs/encoding#structure


### PR DESCRIPTION
Hey there! I went to use this generator, however I found that with zig version `0.12.0-dev.283+8976ad7ec` (very recent build), it was failing with this error:

```
$ zig build install
zig build-exe protoc-gen-zig Debug native: error: the following command failed with 1 compilation errors:
/Users/jcalabro/.bin/zig/zig build-exe /Users/jcalabro/go/src/github.com/jcalabro/zig-protobuf/bootstrapped-generator/main.zig --cache-dir /Users/jcalabro/go/src/github.com/jcalabro/zig-protobuf/zig-cache --global-cache-dir /Users/jcalabro/.cache/zig --name protoc-gen-zig --mod protobuf::/Users/jcalabro/go/src/github.com/jcalabro/zig-protobuf/src/protobuf.zig --deps protobuf --listen=-
Build Summary: 2/5 steps succeeded; 1 failed (disable with --summary none)
install transitive failure
└─ install protoc-gen-zig transitive failure
   └─ zig build-exe protoc-gen-zig Debug native 1 errors
src/protobuf.zig:90:5: error: union field 'String' ordered differently than corresponding enum field
    String,
    ^~~~~~
src/protobuf.zig:64:81: note: enum field here
pub const FieldTypeTag = enum { Varint, FixedInt, SubMessage, List, PackedList, String, OneOf };
                                                                                ^~~~~~
referenced by:
    FieldType: src/protobuf.zig:86:23
    fd: src/protobuf.zig:119:56
    remaining reference traces hidden; use '-freference-trace' to see all reference traces
```

Once I changed the order of the enum, everything worked as expected, and I can generate my protobuf files no problem.