### PR TITLE
docs: add missing 'paths' field to `build.zig.zon` example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This project is currently able to handle all scalar types for encoding, decoding
     .{
         .name = "my_project",
         .version = "0.0.1",
+        .paths = .{""},
         .dependencies = .{
             .protobuf = .{
                 .url = "https://github.com/Arwalk/zig-protobuf/archive/<some-commit-sha>.tar.gz",


### PR DESCRIPTION
This commit adds the `.paths = .{""},` line to the `build.zig.zon` code snippet in the README. This change resolves an issue where omitting the 'paths' field led to a "missing top-level 'paths' field" error during the `zig build` process.

Zig Docs: [doc/build.zig.zon.md](https://github.com/ziglang/zig/blob/4129996211edd30b25c23454520fd78b2a70394b/doc/build.zig.zon.md?plain=1#L68)
Zig Version: `v0.12.0-dev.1861+412999621`