### PR TITLE
Update for zig 0.12.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,6 +3,6 @@ RUN git config --global core.autocrlf input
 
 ADD . .
 
-RUN bash ./install-zig.sh 0.12.0-dev.3283+b8920bceb
+RUN bash ./install-zig.sh 0.12.0
 
 ENV AGREE=true

--- a/build.zig
+++ b/build.zig
@@ -94,13 +94,13 @@ pub fn build(b: *std.Build) !void {
         }),
     };
 
-    const convertStep = RunProtocStep.create(b, b, target,  .{
+    const convertStep = RunProtocStep.create(b, b, target, .{
         .destination_directory = .{ .path = "tests/.generated" },
         .source_files = &.{"tests/protos_for_test/generated_in_ci.proto"},
         .include_directories = &.{"tests/protos_for_test"},
     });
 
-    const convertStep2 = RunProtocStep.create(b, b, target,  .{
+    const convertStep2 = RunProtocStep.create(b, b, target, .{
         .destination_directory = .{ .path = "tests/generated" },
         .source_files = &.{ "tests/protos_for_test/all.proto", "tests/protos_for_test/whitespace-in-name.proto" },
         .include_directories = &.{"tests/protos_for_test"},
@@ -188,7 +188,7 @@ pub const RunProtocStep = struct {
     fn make(step: *Step, prog_node: *std.Progress.Node) !void {
         _ = prog_node;
         const b = step.owner;
-        const self = @fieldParentPtr(RunProtocStep, "step", step);
+        const self: *RunProtocStep = @fieldParentPtr("step", step);
 
         const absolute_dest_dir = self.destination_directory.getPath(b);
 
@@ -257,7 +257,6 @@ pub fn buildGenerator(b: *std.Build, opt: GenOptions) *std.Build.Step.Compile {
     const module = b.addModule("protobuf", .{
         .root_source_file = .{ .path = "src/protobuf.zig" },
     });
-
 
     exe.root_module.addImport("protobuf", module);
 


### PR DESCRIPTION
Closes #44 

- The only thing in zig 0.12.0 that looks like it requires a fix is the change to `@fieldParentPtr` that [now only takes 2 parameters](https://ziglang.org/download/0.12.0/release-notes.html#fieldParentPtr)
- `zig fmt` seems to have made a few changes to `build.zig` also
- I've updated the version in the Dockerfile to just 0.12.0, but I'm not sure if the intention is to use some `0.13.0-dev` version instead. I did leave the version as `master` in the GitHub action. Can change any of these as desired.