### PR TITLE
fix: memory leak when decoding Lists of Bytes

### DIFF
--- a/src/protobuf.zig
+++ b/src/protobuf.zig
@@ -586,7 +586,7 @@ fn deinit_field(result: anytype, comptime field_name: []const u8, comptime ftype
             }
         },
         .List => |list_type| {
-            if (list_type == .SubMessage or list_type == .String) {
+            if (list_type == .SubMessage or list_type == .String or list_type == .Bytes) {
                 for (@field(result, field_name).items) |item| {
                     item.deinit();
                 }

--- a/src/protobuf.zig
+++ b/src/protobuf.zig
@@ -586,10 +586,13 @@ fn deinit_field(result: anytype, comptime field_name: []const u8, comptime ftype
             }
         },
         .List => |list_type| {
-            if (list_type == .SubMessage or list_type == .String or list_type == .Bytes) {
-                for (@field(result, field_name).items) |item| {
-                    item.deinit();
-                }
+            switch (list_type) {
+                .SubMessage, .String, .Bytes => {
+                    for (@field(result, field_name).items) |item| {
+                        item.deinit();
+                    }
+                },
+                .Varint, .FixedInt => {},
             }
             @field(result, field_name).deinit();
         },

--- a/tests/generated/tests.pb.zig
+++ b/tests/generated/tests.pb.zig
@@ -189,3 +189,13 @@ pub const WithBytes = struct {
 
     pub usingnamespace protobuf.MessageMixins(@This());
 };
+
+pub const WithRepeatedBytes = struct {
+    byte_field: ArrayList(ManagedString),
+
+    pub const _desc_table = .{
+        .byte_field = fd(1, .{ .List = .Bytes }),
+    };
+
+    pub usingnamespace protobuf.MessageMixins(@This());
+};

--- a/tests/protos_for_test/all.proto
+++ b/tests/protos_for_test/all.proto
@@ -85,3 +85,7 @@ message WithRepeatedStrings {
 message WithBytes {
   bytes byte_field = 1;
 }
+
+message WithRepeatedBytes {
+  repeated bytes byte_field = 1;
+}


### PR DESCRIPTION
Messages that include a `repeated` field of type `bytes` are not properly freed due to a missing condition in `deinit_field()` which only cares for list of other message types or strings, but not bytes.

This commit introduces a new unit test that fails if decoding a message with a list of bytes leaks and fix, that makes the unit test pass.