### PR TITLE
Fix integer encoding

### DIFF
--- a/src/protobuf.zig
+++ b/src/protobuf.zig
@@ -196,28 +196,27 @@ fn insert_raw_varint(pb: *ArrayList(u8), size: u64, start_index: usize) Allocato
 
 fn encode_zig_zag(int: anytype) u64 {
     const type_of_val = @TypeOf(int);
-    const to_int64 : i64 = switch (type_of_val) {
+    const to_int64: i64 = switch (type_of_val) {
         i32 => @intCast(int),
         i64 => int,
         else => @compileError("should not be here"),
     };
     const calc = (to_int64 << 1) ^ (to_int64 >> 63);
-    return @bitCast(calc);    
+    return @bitCast(calc);
 }
 
 test "encode zig zag test" {
-    try testing.expectEqual(@as(u64, 0),encode_zig_zag(@as(i32, 0)));
-    try testing.expectEqual(@as(u64, 1),encode_zig_zag(@as(i32, -1)));
-    try testing.expectEqual(@as(u64, 2),encode_zig_zag(@as(i32, 1)));
-    try testing.expectEqual(@as(u64, 0xfffffffe),encode_zig_zag(@as(i32, std.math.maxInt(i32))));
-    try testing.expectEqual(@as(u64, 0xffffffff),encode_zig_zag(@as(i32, std.math.minInt(i32))));
+    try testing.expectEqual(@as(u64, 0), encode_zig_zag(@as(i32, 0)));
+    try testing.expectEqual(@as(u64, 1), encode_zig_zag(@as(i32, -1)));
+    try testing.expectEqual(@as(u64, 2), encode_zig_zag(@as(i32, 1)));
+    try testing.expectEqual(@as(u64, 0xfffffffe), encode_zig_zag(@as(i32, std.math.maxInt(i32))));
+    try testing.expectEqual(@as(u64, 0xffffffff), encode_zig_zag(@as(i32, std.math.minInt(i32))));
 
-
-    try testing.expectEqual(@as(u64, 0),encode_zig_zag(@as(i64, 0)));
-    try testing.expectEqual(@as(u64, 1),encode_zig_zag(@as(i64, -1)));
-    try testing.expectEqual(@as(u64, 2),encode_zig_zag(@as(i64, 1)));
-    try testing.expectEqual(@as(u64, 0xfffffffffffffffe),encode_zig_zag(@as(i64, std.math.maxInt(i64))));
-    try testing.expectEqual(@as(u64, 0xffffffffffffffff),encode_zig_zag(@as(i64, std.math.minInt(i64))));
+    try testing.expectEqual(@as(u64, 0), encode_zig_zag(@as(i64, 0)));
+    try testing.expectEqual(@as(u64, 1), encode_zig_zag(@as(i64, -1)));
+    try testing.expectEqual(@as(u64, 2), encode_zig_zag(@as(i64, 1)));
+    try testing.expectEqual(@as(u64, 0xfffffffffffffffe), encode_zig_zag(@as(i64, std.math.maxInt(i64))));
+    try testing.expectEqual(@as(u64, 0xffffffffffffffff), encode_zig_zag(@as(i64, std.math.minInt(i64))));
 }
 
 /// Appends a varint to the pb array.
@@ -836,11 +835,11 @@ fn decode_zig_zag(comptime T: type, raw: u64) DecodingError!T {
     comptime {
         switch (T) {
             i32, i64 => {},
-            else => @compileError("should only pass i32 or i64 here")
+            else => @compileError("should only pass i32 or i64 here"),
         }
     }
 
-    const v : T = block: {
+    const v: T = block: {
         var v = raw >> 1;
         if (raw & 0x1 != 0) {
             v = v ^ (~@as(u64, 0));
@@ -856,17 +855,16 @@ fn decode_zig_zag(comptime T: type, raw: u64) DecodingError!T {
 
 test "decode zig zag test" {
     try testing.expectEqual(@as(i32, 0), decode_zig_zag(i32, 0));
-    try testing.expectEqual(@as(i32, -1),decode_zig_zag(i32, 1));
-    try testing.expectEqual(@as(i32, 1),decode_zig_zag(i32, 2));
-    try testing.expectEqual(@as(i32, std.math.maxInt(i32)),decode_zig_zag(i32, 0xfffffffe));
-    try testing.expectEqual(@as(i32, std.math.minInt(i32)),decode_zig_zag(i32, 0xffffffff));
+    try testing.expectEqual(@as(i32, -1), decode_zig_zag(i32, 1));
+    try testing.expectEqual(@as(i32, 1), decode_zig_zag(i32, 2));
+    try testing.expectEqual(@as(i32, std.math.maxInt(i32)), decode_zig_zag(i32, 0xfffffffe));
+    try testing.expectEqual(@as(i32, std.math.minInt(i32)), decode_zig_zag(i32, 0xffffffff));
 
-
-    try testing.expectEqual(@as(i64, 0),decode_zig_zag(i64, 0));
-    try testing.expectEqual(@as(i64, -1),decode_zig_zag(i64, 1));
-    try testing.expectEqual(@as(i64, 1),decode_zig_zag(i64, 2));
-    try testing.expectEqual(@as(i64, std.math.maxInt(i64)),decode_zig_zag(i64, 0xfffffffffffffffe));
-    try testing.expectEqual(@as(i64, std.math.minInt(i64)),decode_zig_zag(i64, 0xffffffffffffffff));
+    try testing.expectEqual(@as(i64, 0), decode_zig_zag(i64, 0));
+    try testing.expectEqual(@as(i64, -1), decode_zig_zag(i64, 1));
+    try testing.expectEqual(@as(i64, 1), decode_zig_zag(i64, 2));
+    try testing.expectEqual(@as(i64, std.math.maxInt(i64)), decode_zig_zag(i64, 0xfffffffffffffffe));
+    try testing.expectEqual(@as(i64, std.math.minInt(i64)), decode_zig_zag(i64, 0xffffffffffffffff));
 }
 
 /// Get a real varint of type T from a raw u64 data.
@@ -886,7 +884,7 @@ fn decode_varint_value(comptime T: type, comptime varint_type: VarintType, raw: 
             },
             .Bool => raw != 0,
             .Enum => block: {
-                const as_u32 : u32 = std.math.cast(u32, raw) orelse return DecodingError.InvalidInput;
+                const as_u32: u32 = std.math.cast(u32, raw) orelse return DecodingError.InvalidInput;
                 break :block std.meta.intToEnum(T, @as(i32, @bitCast(as_u32))) catch DecodingError.InvalidInput;
             },
             else => @compileError("Invalid type " ++ @typeName(T) ++ " passed"),

--- a/src/protobuf.zig
+++ b/src/protobuf.zig
@@ -207,7 +207,7 @@ fn append_as_varint(pb: *ArrayList(u8), int: anytype, comptime varint_type: Vari
                     break :blk @as(u64, @intCast((int >> (bitsize - 1)) ^ (int << 1)));
                 },
                 .Simple => {
-                    break :blk @as(std.meta.Int(.unsigned, bitsize), @bitCast(int));
+                    break :blk @bitCast(@as(i64, @intCast(int)));
                 },
             }
         } else {
@@ -821,7 +821,8 @@ fn decode_varint_value(comptime T: type, comptime varint_type: VarintType, raw: 
         .Simple => switch (@typeInfo(T)) {
             .Int => switch (T) {
                 u8, u16, u32, u64 => @as(T, @intCast(raw)),
-                i32, i64 => @as(T, @bitCast(@as(std.meta.Int(.unsigned, @bitSizeOf(T)), @truncate(raw)))),
+                i64 => @as(T, @bitCast(raw)),
+                i32 => std.math.cast(i32, @as(i64, @bitCast(raw))) orelse error.InvalidInput,
                 else => @compileError("Invalid type " ++ @typeName(T) ++ " passed"),
             },
             .Bool => raw != 0,

--- a/tests/alltypes.zig
+++ b/tests/alltypes.zig
@@ -93,8 +93,8 @@ test "msg-longs.proto" {
     try testing.expectEqual(@as(i64, 9223372036854775807), decoded.int64_field_max);
     try testing.expectEqual(@as(i64, -9223372036854775808), decoded.sfixed64_field_min);
     try testing.expectEqual(@as(i64, 9223372036854775807), decoded.sfixed64_field_max);
-    // try testing.expectEqual(@as(i64, -9223372036854775808), decoded.sint64_field_min);
-    // try testing.expectEqual(@as(i64, 9223372036854775807), decoded.sint64_field_max);
+    try testing.expectEqual(@as(i64, -9223372036854775808), decoded.sint64_field_min);
+    try testing.expectEqual(@as(i64, 9223372036854775807), decoded.sint64_field_max);
     try testing.expectEqual(@as(u64, 0), decoded.uint64_field_min);
     try testing.expectEqual(@as(u64, 18446744073709551615), decoded.uint64_field_max);
 }

--- a/tests/protos_for_test/generated_in_ci.proto
+++ b/tests/protos_for_test/generated_in_ci.proto
@@ -37,6 +37,9 @@ message DemoWithAllVarint {
       SomeValue = 0;
       SomeOther = 1;
       AndAnother = 2;
+      Negative = -1;
+      MaxNeg = -2147483648;
+      Max = 2147483647;
     };
 
     sint32 sint32 = 1;

--- a/tests/tests_varints.zig
+++ b/tests/tests_varints.zig
@@ -417,10 +417,10 @@ test "sint32, sint64 to -1" {
     try check(demo, "08011001");
 }
 
-//test "sint32, sint64, uint32, uint64 to their max value" {
-//    const demo = tests.DemoWithAllVarint{ .sint32 = std.math.maxInt(i32), .sint64 = std.math.maxInt(i64), .uint32 = std.math.maxInt(u32), .uint64 = std.math.maxInt(u64) };
-//    try check(demo, "08feffffff0f10feffffffffffffffff0118ffffffff0f20ffffffffffffffffff01");
-//}
+test "sint32, sint64, uint32, uint64 to their max value" {
+    const demo = tests.DemoWithAllVarint{ .sint32 = std.math.maxInt(i32), .sint64 = std.math.maxInt(i64), .uint32 = std.math.maxInt(u32), .uint64 = std.math.maxInt(u64) };
+    try check(demo, "08feffffff0f10feffffffffffffffff0118ffffffff0f20ffffffffffffffffff01");
+}
 
 test "sint32, sint64 to their min value" {
     const demo = tests.DemoWithAllVarint{ .sint32 = std.math.minInt(i32), .sint64 = std.math.minInt(i64) };

--- a/tests/tests_varints.zig
+++ b/tests/tests_varints.zig
@@ -388,7 +388,7 @@ test "basic encoding with negative numbers" {
     defer demo.deinit();
     defer testing.allocator.free(obtained);
     // 0x08
-    try testing.expectEqualSlices(u8, &[_]u8{ 0x08, 0x03, 0x10, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,  0xFF, 0xFF, 0xFF, 0xFF, 0x01 }, obtained);
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x08, 0x03, 0x10, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01 }, obtained);
     const decoded = try tests.WithNegativeIntegers.decode(obtained, testing.allocator);
     try testing.expectEqual(demo, decoded);
 }

--- a/tests/tests_varints.zig
+++ b/tests/tests_varints.zig
@@ -417,14 +417,14 @@ test "sint32, sint64 to -1" {
     try check(demo, "08011001");
 }
 
-test "sint32, sint64, uint32, uint64 to their max value" {
-    const demo = tests.DemoWithAllVarint{ .sint32 = 0x7FFFFFFF, .sint64 = 0x7FFFFFFFFFFFFFFF, .uint32 = 0xFFFFFFFF, .uint64 = 0xFFFFFFFFFFFFFFFF };
-    try check(demo, "08feffffff0f10feffffffffffffffff0118ffffffff0f20ffffffffffffffffff01");
-}
+//test "sint32, sint64, uint32, uint64 to their max value" {
+//    const demo = tests.DemoWithAllVarint{ .sint32 = std.math.maxInt(i32), .sint64 = std.math.maxInt(i64), .uint32 = std.math.maxInt(u32), .uint64 = std.math.maxInt(u64) };
+//    try check(demo, "08feffffff0f10feffffffffffffffff0118ffffffff0f20ffffffffffffffffff01");
+//}
 
 test "sint32, sint64 to their min value" {
-    const demo = tests.DemoWithAllVarint{ .sint32 = -2147483648, .sint64 = -9223372036854775808 };
-    try check(demo, "08feffffff0f10feffffffffffffffff0118ffffffff0f20ffffffffffffffffff01");
+    const demo = tests.DemoWithAllVarint{ .sint32 = std.math.minInt(i32), .sint64 = std.math.minInt(i64) };
+    try check(demo, "08ffffffff0f10ffffffffffffffffff01");
 }
 
 test "int32, int64 to their low boundaries (-1, 1)" {


### PR DESCRIPTION
This branch aims at fixing i32 encoding as identified in https://github.com/Arwalk/zig-protobuf/discussions/82
I also took the opportunity to have a better handling of most zig zag encoding, as i identified that it was breaking on limits.

This will be a major release as it is technically a breaking change. We will have to cover what the error was and how to recover from it if it was encountered in production.

@menduz sorry for the burden but it would be nice to have a thorough review, i generated the values for the tests with some other reference implementations, but if you could do it on your side too... Thanks in advance.