### PR TITLE
Adjust readme: use `zig fetch` in `## How to use`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ There are 2 branches you can use for your development.
 1. Use the `protobuf` module. In your `build.zig`'s build function, add the dependency as module before
 `b.installArtifact(exe)`.
     ```zig
+    pub fn build(b: *std.Build) !void {
         // first create a build for the dependency
         const protobuf_dep = b.dependency("protobuf", .{
             .target = target,
@@ -46,6 +47,7 @@ There are 2 branches you can use for your development.
 
         // and lastly use the dependency as a module
         exe.root_module.addImport("protobuf", protobuf_dep.module("protobuf"));
+    }
     ```
 
 ## Generating .zig files out of .proto definitions

--- a/README.md
+++ b/README.md
@@ -32,23 +32,12 @@ There are 2 branches you can use for your development.
 ## How to use
 
 1. Add `protobuf` to your `build.zig.zon`.  
-    ```zig
-    .{
-        .name = "my_project",
-        .version = "0.0.1",
-        .paths = .{""},
-        .dependencies = .{
-            .protobuf = .{
-                .url = "https://github.com/Arwalk/zig-protobuf/archive/<some-commit-sha>.tar.gz",
-                .hash = "12ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-                // leave the hash as is, the build system will tell you which hash to put here based on your commit
-            },
-        },
-    }
+    ```sh
+    zig fetch --save "git+https://github.com/Arwalk/zig-protobuf#v2.0.0"
     ```
-1. Use the `protobuf` module   
+1. Use the `protobuf` module. In your `build.zig`'s build function, add the dependency as module before
+`b.installArtifact(exe)`.
     ```zig
-    pub fn build(b: *std.Build) !void {
         // first create a build for the dependency
         const protobuf_dep = b.dependency("protobuf", .{
             .target = target,
@@ -57,9 +46,7 @@ There are 2 branches you can use for your development.
 
         // and lastly use the dependency as a module
         exe.root_module.addImport("protobuf", protobuf_dep.module("protobuf"));
-    }
     ```
-
 
 ## Generating .zig files out of .proto definitions
 


### PR DESCRIPTION
Hey folks,
i finally got the time to check out this project :). First of all thanks alot for doing this <3! I am not super experienced with contributing to open source projects, but i want to dive into helping out in some projects and this fits very fitting.

I am working with protobuf at work, too and plan to contribute more frequently. I just need to get into the project.

Lastly as i was using this project just now and realized the `How to use` instructions could be simpler ;), so i thought id give something back immediatly. So here are my 2 cents:

> [!NOTE]
> ### Pull Request Description
> Small adjustment to the `README.md`:
> * As an example on how to use the project provide a simpler example using `zig fetch`
> * ~Adjust the existing example for adding the module in the `build.zig` file to have additional information where it belongs and remove the wrap from `pub fn build(b: *std.Build) void {` for easier copying 😇~ (REVERTED).

WDYT?

Enjoy the rest of your weeks everyone 🍿!