### PR TITLE
Fix message when missing unzip dependency

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -499,7 +499,7 @@ fn ensureCanUnzipFiles(allocator: std.mem.Allocator) void {
         .argv = &.{"unzip"},
         .cwd = sdkPath("/"),
     }) catch { // e.g. FileNotFound
-        std.log.err("zig-protobuf: error: 'unzip' failed. Is curl not installed?", .{});
+        std.log.err("zig-protobuf: error: 'unzip' failed. Is unzip not installed?", .{});
         std.process.exit(1);
     };
     defer {
@@ -507,7 +507,7 @@ fn ensureCanUnzipFiles(allocator: std.mem.Allocator) void {
         allocator.free(result.stdout);
     }
     if (result.term.Exited != 0) {
-        std.log.err("zig-protobuf: error: 'unzip' failed. Is curl not installed?", .{});
+        std.log.err("zig-protobuf: error: 'unzip' failed. Is unzip not installed?", .{});
         std.process.exit(1);
     }
 }


### PR DESCRIPTION
Building without `unzip` installed points the user towards a different dependency as the reason for build failure. It's not too difficult to figure out what the actual issue is, but this should make the actual failure cause more clear.