### PR TITLE
make UnionDecodeError pub, replace usingnamespace

### DIFF
--- a/bootstrapped-generator/main.zig
+++ b/bootstrapped-generator/main.zig
@@ -328,11 +328,11 @@ const GenerationContext = struct {
                             const raw_type = type_name.getSlice();
                             const dep_name = raw_type[1..]; // Remove leading dot
                             const last_dot = std.mem.lastIndexOf(u8, dep_name, ".");
-                            const simple_name = if (last_dot) |idx| dep_name[idx + 1..] else dep_name;
-                            
+                            const simple_name = if (last_dot) |idx| dep_name[idx + 1 ..] else dep_name;
+
                             // Get the current message name from fqn
                             const current_msg = fqn.name().buf;
-                            
+
                             if (std.mem.eql(u8, simple_name, current_msg)) {
                                 prefix = "?ManagedStruct(";
                                 postfix = ")";
@@ -602,20 +602,50 @@ const GenerationContext = struct {
 
             try ctx.generateEnums(list, messageFqn, file, m.enum_type);
             try ctx.generateMessages(list, messageFqn, file, m.nested_type);
-
-            try list.append(try std.fmt.allocPrint(allocator,
+            const mixed_builtins =
                 \\
-                \\    pub usingnamespace protobuf.MessageMixins(@This());
-                \\}};
+                \\    pub fn encode(self: @This(), allocator: Allocator) Allocator.Error![]u8 {
+                \\        return protobuf.pb_encode(self, allocator);
+                \\    }
+                \\    pub fn decode(input: []const u8, allocator: Allocator) protobuf.UnionDecodingError!@This() {
+                \\        return protobuf.pb_decode(@This(), input, allocator);
+                \\    }
+                \\    pub fn init(allocator: Allocator) @This() {
+                \\        return protobuf.pb_init(@This(), allocator);
+                \\    }
+                \\    pub fn deinit(self: @This()) void {
+                \\        return protobuf.pb_deinit(self);
+                \\    }
+                \\    pub fn dupe(self: @This(), allocator: Allocator) Allocator.Error!@This() {
+                \\        return protobuf.pb_dupe(@This(), self, allocator);
+                \\    }
+                \\    pub fn json_decode(input: []const u8, options: protobuf.json.ParseOptions, allocator: Allocator) !std.json.Parsed(@This()) {
+                \\        return protobuf.pb_json_decode(@This(), input, options, allocator);
+                \\    }
+                \\    pub fn json_encode(self: @This(), options: protobuf.json.StringifyOptions, allocator: Allocator) ![]const u8 {
+                \\        return protobuf.pb_json_encode(self, options, allocator);
+                \\    }
+                \\    // This method is used by std.json
+                \\    // internally for deserialization. DO NOT RENAME!
+                \\    pub fn jsonParse(allocator: Allocator, source: anytype, options: protobuf.json.ParseOptions) !@This() {
+                \\        try protobuf.jsonParseT(@This(), allocator, source, options);
+                \\    }
                 \\
-            , .{}));
+                \\    // This method is used by std.json
+                \\    // internally for serialization. DO NOT RENAME!
+                \\    pub fn jsonStringify(self: *const @This(), jws: anytype) !void {
+                \\        try protobuf.jsonStringifyT(@This(), self, jws);
+                \\    }
+                \\};
+            ;
+            try list.append(mixed_builtins);
         }
     }
 
     /// Analyzes message dependencies to detect self-referential messages
     fn analyzeMessageDependencies(self: *Self, fqn: FullName, message: descriptor.DescriptorProto) !bool {
         const message_name = message.name.?.getSlice();
-        const full_message_name = fqn.buf;  // Use package name directly
+        const full_message_name = fqn.buf; // Use package name directly
         var deps = std.StringHashMap(bool).init(allocator);
 
         // Check fields for message types
@@ -629,8 +659,8 @@ const GenerationContext = struct {
 
                         // Check for direct self-reference by comparing the last part of the type name
                         const last_dot = std.mem.lastIndexOf(u8, dep_name, ".");
-                        const simple_name = if (last_dot) |idx| dep_name[idx + 1..] else dep_name;
-                        
+                        const simple_name = if (last_dot) |idx| dep_name[idx + 1 ..] else dep_name;
+
                         if (std.mem.eql(u8, simple_name, message_name)) {
                             return true;
                         }
@@ -661,9 +691,9 @@ const GenerationContext = struct {
 
             while (it.next()) |dep| {
                 const last_dot = std.mem.lastIndexOf(u8, dep.key_ptr.*, ".");
-                const simple_name = if (last_dot) |idx| dep.key_ptr.*[idx + 1..] else dep.key_ptr.*;
+                const simple_name = if (last_dot) |idx| dep.key_ptr.*[idx + 1 ..] else dep.key_ptr.*;
                 const last_dot_msg = std.mem.lastIndexOf(u8, message_name, ".");
-                const msg_simple_name = if (last_dot_msg) |idx| message_name[idx + 1..] else message_name;
+                const msg_simple_name = if (last_dot_msg) |idx| message_name[idx + 1 ..] else message_name;
 
                 // Check for self-reference by comparing simple names
                 if (std.mem.eql(u8, simple_name, msg_simple_name)) {

--- a/bootstrapped-generator/main.zig
+++ b/bootstrapped-generator/main.zig
@@ -602,7 +602,7 @@ const GenerationContext = struct {
 
             try ctx.generateEnums(list, messageFqn, file, m.enum_type);
             try ctx.generateMessages(list, messageFqn, file, m.nested_type);
-            const mixed_builtins =
+            const message_mixins =
                 \\
                 \\    pub fn encode(self: @This(), allocator: Allocator) Allocator.Error![]u8 {
                 \\        return protobuf.pb_encode(self, allocator);
@@ -636,9 +636,12 @@ const GenerationContext = struct {
                 \\    pub fn jsonStringify(self: *const @This(), jws: anytype) !void {
                 \\        try protobuf.jsonStringifyT(@This(), self, jws);
                 \\    }
-                \\};
             ;
-            try list.append(mixed_builtins);
+            try list.append(message_mixins);
+            try list.append(
+                \\};
+                \\
+            );
         }
     }
 

--- a/src/protobuf.zig
+++ b/src/protobuf.zig
@@ -19,7 +19,7 @@ const VarintType = enum { Simple, ZigZagOptimized };
 
 const DecodingError = error{ NotEnoughData, InvalidInput };
 
-const UnionDecodingError = DecodingError || Allocator.Error;
+pub const UnionDecodingError = DecodingError || Allocator.Error;
 
 pub const ManagedStringTag = enum { Owned, Const, Empty };
 
@@ -1669,122 +1669,130 @@ pub fn MessageMixins(comptime Self: type) type {
             source: anytype,
             options: json.ParseOptions,
         ) !Self {
-            if (.object_begin != try source.next()) {
-                return error.UnexpectedToken;
-            }
-
-            // Mainly taken from 0.13.0's source code
-            var result: Self = undefined;
-            const structInfo = @typeInfo(Self).@"struct";
-            var fields_seen = [_]bool{false} ** structInfo.fields.len;
-
-            while (true) {
-                var name_token: ?json.Token = try source.nextAllocMax(
-                    allocator,
-                    .alloc_if_needed,
-                    options.max_value_len.?,
-                );
-                const field_name = switch (name_token.?) {
-                    inline .string, .allocated_string => |slice| slice,
-                    .object_end => { // No more fields.
-                        break;
-                    },
-                    else => {
-                        return error.UnexpectedToken;
-                    },
-                };
-
-                inline for (structInfo.fields, 0..) |field, i| {
-                    if (field.is_comptime) {
-                        @compileError("comptime fields are not supported: " ++ @typeName(Self) ++ "." ++ field.name);
-                    }
-
-                    const yes1 = std.mem.eql(u8, field.name, field_name);
-                    const camel_case_name = comptime to_camel_case(field.name);
-                    var yes2: bool = undefined;
-                    if (comptime std.mem.eql(u8, field.name, camel_case_name)) {
-                        yes2 = false;
-                    } else {
-                        yes2 = std.mem.eql(u8, camel_case_name, field_name);
-                    }
-
-                    if (yes1 and yes2) {
-                        return error.UnexpectedToken;
-                    } else if (yes1 or yes2) {
-                        // Free the name token now in case we're using an
-                        // allocator that optimizes freeing the last
-                        // allocated object. (Recursing into innerParse()
-                        // might trigger more allocations.)
-                        freeAllocated(allocator, name_token.?);
-                        name_token = null;
-                        if (fields_seen[i]) {
-                            switch (options.duplicate_field_behavior) {
-                                .use_first => {
-                                    // Parse and ignore the redundant value.
-                                    // We don't want to skip the value,
-                                    // because we want type checking.
-                                    try parseStructField(
-                                        Self,
-                                        &result,
-                                        field,
-                                        allocator,
-                                        source,
-                                        options,
-                                    );
-                                    break;
-                                },
-                                .@"error" => return error.DuplicateField,
-                                .use_last => {},
-                            }
-                        }
-                        try parseStructField(
-                            Self,
-                            &result,
-                            field,
-                            allocator,
-                            source,
-                            options,
-                        );
-                        fields_seen[i] = true;
-                        break;
-                    }
-                } else {
-                    // Didn't match anything.
-                    freeAllocated(allocator, name_token.?);
-                    if (options.ignore_unknown_fields) {
-                        try source.skipValue();
-                    } else {
-                        return error.UnknownField;
-                    }
-                }
-            }
-            try fillDefaultStructValues(Self, &result, &fields_seen);
-            return result;
+            try jsonParseT(Self, allocator, source, options);
         }
 
         // This method is used by std.json
         // internally for serialization. DO NOT RENAME!
         pub fn jsonStringify(self: *const Self, jws: anytype) !void {
-            try jws.beginObject();
-
-            inline for (@typeInfo(Self).@"struct".fields) |fieldInfo| {
-                const camel_case_name = comptime to_camel_case(fieldInfo.name);
-
-                if (switch (@typeInfo(fieldInfo.type)) {
-                    .optional => @field(self, fieldInfo.name) != null,
-                    else => true,
-                }) try jws.objectField(camel_case_name);
-
-                try stringify_struct_field(
-                    @field(self, fieldInfo.name),
-                    @field(Self._desc_table, fieldInfo.name),
-                    jws,
-                );
-            }
-
-            try jws.endObject();
+            try jsonStringifyT(Self, self, jws);
         }
     };
+}
+
+pub fn jsonParseT(T: type, allocator: Allocator, source: anytype, options: json.ParseOptions) !T {
+    if (.object_begin != try source.next()) {
+        return error.UnexpectedToken;
+    }
+
+    // Mainly taken from 0.13.0's source code
+    var result: T = undefined;
+    const structInfo = @typeInfo(T).@"struct";
+    var fields_seen = [_]bool{false} ** structInfo.fields.len;
+
+    while (true) {
+        var name_token: ?json.Token = try source.nextAllocMax(
+            allocator,
+            .alloc_if_needed,
+            options.max_value_len.?,
+        );
+        const field_name = switch (name_token.?) {
+            inline .string, .allocated_string => |slice| slice,
+            .object_end => { // No more fields.
+                break;
+            },
+            else => {
+                return error.UnexpectedToken;
+            },
+        };
+
+        inline for (structInfo.fields, 0..) |field, i| {
+            if (field.is_comptime) {
+                @compileError("comptime fields are not supported: " ++ @typeName(T) ++ "." ++ field.name);
+            }
+
+            const yes1 = std.mem.eql(u8, field.name, field_name);
+            const camel_case_name = comptime to_camel_case(field.name);
+            var yes2: bool = undefined;
+            if (comptime std.mem.eql(u8, field.name, camel_case_name)) {
+                yes2 = false;
+            } else {
+                yes2 = std.mem.eql(u8, camel_case_name, field_name);
+            }
+
+            if (yes1 and yes2) {
+                return error.UnexpectedToken;
+            } else if (yes1 or yes2) {
+                // Free the name token now in case we're using an
+                // allocator that optimizes freeing the last
+                // allocated object. (Recursing into innerParse()
+                // might trigger more allocations.)
+                freeAllocated(allocator, name_token.?);
+                name_token = null;
+                if (fields_seen[i]) {
+                    switch (options.duplicate_field_behavior) {
+                        .use_first => {
+                            // Parse and ignore the redundant value.
+                            // We don't want to skip the value,
+                            // because we want type checking.
+                            try parseStructField(
+                                T,
+                                &result,
+                                field,
+                                allocator,
+                                source,
+                                options,
+                            );
+                            break;
+                        },
+                        .@"error" => return error.DuplicateField,
+                        .use_last => {},
+                    }
+                }
+                try parseStructField(
+                    T,
+                    &result,
+                    field,
+                    allocator,
+                    source,
+                    options,
+                );
+                fields_seen[i] = true;
+                break;
+            }
+        } else {
+            // Didn't match anything.
+            freeAllocated(allocator, name_token.?);
+            if (options.ignore_unknown_fields) {
+                try source.skipValue();
+            } else {
+                return error.UnknownField;
+            }
+        }
+    }
+    try fillDefaultStructValues(T, &result, &fields_seen);
+    return result;
+}
+
+pub fn jsonStringifyT(T: type, self: *const T, jws: anytype) !void {
+    try jws.beginObject();
+
+    inline for (@typeInfo(T).@"struct".fields) |fieldInfo| {
+        const camel_case_name = comptime to_camel_case(fieldInfo.name);
+
+        if (switch (@typeInfo(fieldInfo.type)) {
+            .optional => @field(self, fieldInfo.name) != null,
+            else => true,
+        }) try jws.objectField(camel_case_name);
+
+        try stringify_struct_field(
+            @field(self, fieldInfo.name),
+            @field(T._desc_table, fieldInfo.name),
+            jws,
+        );
+    }
+
+    try jws.endObject();
 }
 
 test "get varint" {


### PR DESCRIPTION
wanting to try -fincremental with zig i stumbled across the use of usingnamespace with the message mixins in the autogenerated pb file.

this merge request changes:
- makes UnionDecodeError pub that it can be used when replacing usingnamespace with the actual fn's
- replaces the usingnamespace message mixins with hardcoded fn's
- refactors jsonParse(...) to pub fn jsonParseT(T:type ...) for less code duplication
- refactors jsonStringify(...) to pub fn jsonStringifyT(T:type ...) for less code duplication

i reccon that way it's a bit more work keeping the fn's in sync if anything changes in message mixins...
this is up to you to decide.

i would be happy to see UnionDecodeError made pub on master regardless of the other changes, because then one could at least replace the usingnamespace's manually.