### PR TITLE
Type name includes the outermost type

### DIFF
--- a/bootstrapped-generator/main.zig
+++ b/bootstrapped-generator/main.zig
@@ -214,10 +214,14 @@ const GenerationContext = struct {
     fn fieldTypeFqn(ctx: *Self, parentFqn: FullName, file: descriptor.FileDescriptorProto, field: descriptor.FieldDescriptorProto) !string {
         if (field.type_name) |typeName| {
             const fullTypeName = FullName{ .buf = typeName.getSlice()[1..] };
-
             if (fullTypeName.parent()) |parent| {
                 if (parent.eql(parentFqn)) {
-                    return fullTypeName.name().buf;
+                    const diff_idx = std.mem.indexOfDiff(
+                        u8,
+                        fullTypeName.buf,
+                        file.package.?.getSlice(),
+                    ).?;
+                    return fullTypeName.buf[diff_idx + 1 ..];
                 }
                 if (parent.eql(FullName{ .buf = file.package.?.getSlice() })) {
                     return fullTypeName.name().buf;
@@ -328,11 +332,11 @@ const GenerationContext = struct {
                             const raw_type = type_name.getSlice();
                             const dep_name = raw_type[1..]; // Remove leading dot
                             const last_dot = std.mem.lastIndexOf(u8, dep_name, ".");
-                            const simple_name = if (last_dot) |idx| dep_name[idx + 1..] else dep_name;
-                            
+                            const simple_name = if (last_dot) |idx| dep_name[idx + 1 ..] else dep_name;
+
                             // Get the current message name from fqn
                             const current_msg = fqn.name().buf;
-                            
+
                             if (std.mem.eql(u8, simple_name, current_msg)) {
                                 prefix = "?ManagedStruct(";
                                 postfix = ")";
@@ -615,7 +619,7 @@ const GenerationContext = struct {
     /// Analyzes message dependencies to detect self-referential messages
     fn analyzeMessageDependencies(self: *Self, fqn: FullName, message: descriptor.DescriptorProto) !bool {
         const message_name = message.name.?.getSlice();
-        const full_message_name = fqn.buf;  // Use package name directly
+        const full_message_name = fqn.buf; // Use package name directly
         var deps = std.StringHashMap(bool).init(allocator);
 
         // Check fields for message types
@@ -629,8 +633,8 @@ const GenerationContext = struct {
 
                         // Check for direct self-reference by comparing the last part of the type name
                         const last_dot = std.mem.lastIndexOf(u8, dep_name, ".");
-                        const simple_name = if (last_dot) |idx| dep_name[idx + 1..] else dep_name;
-                        
+                        const simple_name = if (last_dot) |idx| dep_name[idx + 1 ..] else dep_name;
+
                         if (std.mem.eql(u8, simple_name, message_name)) {
                             return true;
                         }
@@ -661,9 +665,9 @@ const GenerationContext = struct {
 
             while (it.next()) |dep| {
                 const last_dot = std.mem.lastIndexOf(u8, dep.key_ptr.*, ".");
-                const simple_name = if (last_dot) |idx| dep.key_ptr.*[idx + 1..] else dep.key_ptr.*;
+                const simple_name = if (last_dot) |idx| dep.key_ptr.*[idx + 1 ..] else dep.key_ptr.*;
                 const last_dot_msg = std.mem.lastIndexOf(u8, message_name, ".");
-                const msg_simple_name = if (last_dot_msg) |idx| message_name[idx + 1..] else message_name;
+                const msg_simple_name = if (last_dot_msg) |idx| message_name[idx + 1 ..] else message_name;
 
                 // Check for self-reference by comparing simple names
                 if (std.mem.eql(u8, simple_name, msg_simple_name)) {


### PR DESCRIPTION
Recently, I have a problem when having the following example proto file

```
syntax = "proto3";
package dummy;

message A{ // This is a top-level message named 'A'
  int32 az = 1;
  int32 ay = 2;
}

message B{
  // This is a *nested* message also named 'A'
  // It is scoped *only* within message B.
  message A{
    int32 ap = 1;
    int32 aq = 2;
  }

  // This field 'bz' refers to the *nested* message 'A' defined directly above it.
  A bz = 1;
  int32 by = 2;
}
```

The resulted zig file will error with ambiguous reference for field `B.bz`. The type of field `B.bz` should be `B.A`, but the current implementation write the type as `A` only. This PR change it so that the resulting type is `B.A`