### PR TITLE
Add comments from `.proto` into generated Zig files

### DIFF
--- a/bootstrapped-generator/main.zig
+++ b/bootstrapped-generator/main.zig
@@ -183,11 +183,86 @@ const GenerationContext = struct {
         return std.mem.replaceOwned(u8, self.req.file_to_generate.allocator, resolvedRelativePath, "\\", "/");
     }
 
+    const SourceCodeInfo = struct {
+        fn appendComment(out_lines: *std.ArrayList(string), raw_comment: []const u8) !void {
+            var comment_lines = std.mem.splitScalar(u8, raw_comment, '\n');
+            var trailing_empties: usize = 0;
+            while (comment_lines.next()) |comment_line| {
+                if (comment_line.len == 0) {
+                    trailing_empties += 1;
+                } else {
+                    trailing_empties = 0;
+                }
+                try out_lines.append(try std.fmt.allocPrint(
+                    allocator,
+                    "\n//{s}",
+                    .{comment_line},
+                ));
+            }
+            for (0..trailing_empties) |_| {
+                const free_str = out_lines.pop().?;
+                allocator.free(free_str);
+            }
+        }
+
+        /// Get source code location of a message's field.
+        fn getFieldLocation(
+            file: descriptor.FileDescriptorProto,
+            root_path: []const i32,
+            field_number: i32,
+        ) ?descriptor.SourceCodeInfo.Location {
+            const sci = file.source_code_info orelse return null;
+
+            for (sci.location.items) |location| {
+                const path = location.path.items;
+
+                if (path.len != root_path.len + 1) continue;
+                if (!std.mem.eql(i32, root_path, path[0..root_path.len]))
+                    continue;
+
+                const rem_path = path[root_path.len..];
+
+                if (rem_path[0] != field_number) continue;
+
+                return location;
+            }
+
+            return null;
+        }
+
+        /// Get source code location of one value in a message's repeated field.
+        fn getRepeatedFieldLocation(
+            file: descriptor.FileDescriptorProto,
+            root_path: []const i32,
+            field_number: i32,
+            index: usize,
+        ) ?descriptor.SourceCodeInfo.Location {
+            const sci = file.source_code_info orelse return null;
+
+            for (sci.location.items) |location| {
+                const path = location.path.items;
+
+                if (path.len != root_path.len + 2) continue;
+                if (!std.mem.eql(i32, root_path, path[0..root_path.len]))
+                    continue;
+
+                const rem_path = path[root_path.len..];
+
+                if (rem_path[0] != field_number) continue;
+                if (rem_path[1] != index) continue;
+
+                return location;
+            }
+
+            return null;
+        }
+    };
+
     pub fn printFileDeclarations(self: *Self, fqn: FullName, file: descriptor.FileDescriptorProto) !void {
         const list = try self.getOutputList(fqn);
 
-        try self.generateEnums(list, fqn, file, file.enum_type);
-        try self.generateMessages(list, fqn, file, file.message_type);
+        try self.generateEnums(list, fqn, file, &.{}, file);
+        try self.generateMessages(list, fqn, file, &.{}, file);
     }
 
     fn generateEnums(
@@ -195,30 +270,66 @@ const GenerationContext = struct {
         list: *std.ArrayList(string),
         fqn: FullName,
         file: descriptor.FileDescriptorProto,
-        enums: std.ArrayList(descriptor.EnumDescriptorProto),
+        // Source code info path to `root` from `file`.
+        file_root_path: []const i32,
+        // `DescriptorProto` or `FileDescriptorProto`containing enums.
+        root: anytype,
     ) !void {
         _ = ctx;
-        _ = file;
         _ = fqn;
+        const enum_field = if (comptime @TypeOf(root) == descriptor.FileDescriptorProto)
+            @field(descriptor.FileDescriptorProto._desc_table, "enum_type")
+        else if (comptime @TypeOf(root) == descriptor.DescriptorProto)
+            @field(descriptor.DescriptorProto._desc_table, "enum_type")
+        else {
+            @compileError(std.fmt.comptimePrint(
+                "invalid root type `{s}` passed to generateEnums",
+                .{@typeName(@TypeOf(root))},
+            ));
+        };
 
-        for (enums.items) |theEnum| {
+        for (root.enum_type.items, 0..) |theEnum, enum_i| {
             const e: descriptor.EnumDescriptorProto = theEnum;
+
+            // All enum fields should have a source code location.
+            const e_loc = SourceCodeInfo.getRepeatedFieldLocation(
+                file,
+                file_root_path,
+                enum_field.field_number.?,
+                enum_i,
+            ).?;
+
+            if (e_loc.leading_comments) |leading_comments| {
+                try SourceCodeInfo.appendComment(list, leading_comments.getSlice());
+            }
 
             try list.append(try std.fmt.allocPrint(
                 allocator,
-                "\npub const {s} = enum(i32) {{\n",
+                "\npub const {s} = enum(i32) {{",
                 .{e.name.?.getSlice()},
             ));
 
-            for (e.value.items) |elem| {
+            for (e.value.items, 0..) |elem, elem_i| {
+                const field_loc = SourceCodeInfo.getRepeatedFieldLocation(
+                    file,
+                    e_loc.path.items,
+                    2, // `value` field in enum descriptor
+                    elem_i,
+                );
+                if (field_loc) |fl| {
+                    if (fl.leading_comments) |leading_comments| {
+                        try SourceCodeInfo.appendComment(list, leading_comments.getSlice());
+                    }
+                }
+
                 try list.append(try std.fmt.allocPrint(
                     allocator,
-                    "   {s} = {d},\n",
+                    "\n   {s} = {d},",
                     .{ elem.name.?.getSlice(), elem.number orelse 0 },
                 ));
             }
 
-            try list.append("    _,\n};\n\n");
+            try list.append("\n    _,\n};\n\n");
         }
     }
 
@@ -526,11 +637,37 @@ const GenerationContext = struct {
         list: *std.ArrayList(string),
         fqn: FullName,
         file: descriptor.FileDescriptorProto,
-        messages: std.ArrayList(descriptor.DescriptorProto),
+        // Source code info path to `root` from `file`.
+        file_root_path: []const i32,
+        // `DescriptorProto` or `FileDescriptorProto` containing messages.
+        root: anytype,
     ) !void {
-        for (messages.items) |message| {
+        const messages, const message_field = if (comptime @TypeOf(root) == descriptor.FileDescriptorProto)
+            .{ root.message_type, @field(descriptor.FileDescriptorProto._desc_table, "message_type") }
+        else if (comptime @TypeOf(root) == descriptor.DescriptorProto)
+            .{ root.nested_type, @field(descriptor.DescriptorProto._desc_table, "nested_type") }
+        else {
+            @compileError(std.fmt.comptimePrint(
+                "invalid root type `{s}` passed to generateMessages",
+                .{@typeName(@TypeOf(root))},
+            ));
+        };
+
+        for (messages.items, 0..) |message, message_i| {
             const m: descriptor.DescriptorProto = message;
             const messageFqn = try fqn.append(allocator, m.name.?.getSlice());
+
+            const m_loc = SourceCodeInfo.getRepeatedFieldLocation(
+                file,
+                file_root_path,
+                message_field.field_number.?,
+                message_i,
+            );
+            if (m_loc) |loc| {
+                if (loc.leading_comments) |leading_comments| {
+                    try SourceCodeInfo.appendComment(list, leading_comments.getSlice());
+                }
+            }
 
             try list.append(try std.fmt.allocPrint(
                 allocator,
@@ -643,8 +780,13 @@ const GenerationContext = struct {
                 \\
             );
 
-            try ctx.generateEnums(list, messageFqn, file, m.enum_type);
-            try ctx.generateMessages(list, messageFqn, file, m.nested_type);
+            // All non-generated (e.g. not `map` field type) enums and messages
+            // have a source code location. Any generated submessage types won't
+            // have further submessages/enums.
+            if (m_loc) |loc| {
+                try ctx.generateEnums(list, messageFqn, file, loc.path.items, m);
+                try ctx.generateMessages(list, messageFqn, file, loc.path.items, m);
+            }
 
             try list.append(try std.fmt.allocPrint(allocator,
                 \\

--- a/tests/generated/google/protobuf.pb.zig
+++ b/tests/generated/google/protobuf.pb.zig
@@ -71,16 +71,30 @@ pub const FileDescriptorSet = struct {
 pub const FileDescriptorProto = struct {
     name: ?ManagedString = null,
     package: ?ManagedString = null,
+    // Names of files imported by this file.
     dependency: ArrayList(ManagedString),
+    // Indexes of the public imported files in the dependency list above.
     public_dependency: ArrayList(i32),
+    // Indexes of the weak imported files in the dependency list.
+    // For Google-internal migration only. Do not use.
     weak_dependency: ArrayList(i32),
+    // All top-level definitions in this file.
     message_type: ArrayList(DescriptorProto),
     enum_type: ArrayList(EnumDescriptorProto),
     service: ArrayList(ServiceDescriptorProto),
     extension: ArrayList(FieldDescriptorProto),
     options: ?FileOptions = null,
+    // This field contains optional information about the original source code.
+    // You may safely remove this entire field without harming runtime
+    // functionality of the descriptors -- the information is needed only by
+    // development tools.
     source_code_info: ?SourceCodeInfo = null,
+    // The syntax of the proto file.
+    // The supported values are "proto2", "proto3", and "editions".
+    //
+    // If `edition` is present, this value must be "editions".
     syntax: ?ManagedString = null,
+    // The edition of the proto file, which is an opaque string.
     edition: ?ManagedString = null,
 
     pub const _desc_table = .{
@@ -157,6 +171,8 @@ pub const DescriptorProto = struct {
     oneof_decl: ArrayList(OneofDescriptorProto),
     options: ?MessageOptions = null,
     reserved_range: ArrayList(DescriptorProto.ReservedRange),
+    // Reserved field names, which may not be used by fields in the same message.
+    // A given name may only be reserved once.
     reserved_name: ArrayList(ManagedString),
 
     pub const _desc_table = .{
@@ -337,8 +353,16 @@ pub const DescriptorProto = struct {
 };
 
 pub const ExtensionRangeOptions = struct {
+    // The parser stores options it doesn't recognize here. See above.
     uninterpreted_option: ArrayList(UninterpretedOption),
+    // go/protobuf-stripping-extension-declarations
+    // Like Metadata, but we use a repeated field to hold all extension
+    // declarations. This should avoid the size increases of transforming a large
+    // extension range into small ranges in generated binaries.
     declaration: ArrayList(ExtensionRangeOptions.Declaration),
+    // The verification state of the range.
+    // TODO(b/278783756): flip the default to DECLARATION once all empty ranges
+    // are marked as UNVERIFIED.
     verification: ?ExtensionRangeOptions.VerificationState = .UNVERIFIED,
 
     pub const _desc_table = .{
@@ -356,11 +380,23 @@ pub const ExtensionRangeOptions = struct {
     };
 
     pub const Declaration = struct {
+        // The extension number declared within the extension range.
         number: ?i32 = null,
+        // The fully-qualified name of the extension field. There must be a leading
+        // dot in front of the full name.
         full_name: ?ManagedString = null,
+        // The fully-qualified type name of the extension field. Unlike
+        // Metadata.type, Declaration.type must have a leading dot for messages
+        // and enums.
         type: ?ManagedString = null,
+        // Deprecated. Please use "repeated".
         is_repeated: ?bool = null,
+        // If true, indicates that the number is reserved in the extension range,
+        // and any extension field with the number will fail to compile. Set this
+        // when a declared extension field is deleted.
         reserved: ?bool = null,
+        // If true, indicates that the extension must be defined as repeated.
+        // Otherwise the extension must be defined as optional.
         repeated: ?bool = null,
 
         pub const _desc_table = .{
@@ -471,13 +507,53 @@ pub const FieldDescriptorProto = struct {
     name: ?ManagedString = null,
     number: ?i32 = null,
     label: ?FieldDescriptorProto.Label = null,
+    // If type_name is set, this need not be set.  If both this and type_name
+    // are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP.
     type: ?FieldDescriptorProto.Type = null,
+    // For message and enum types, this is the name of the type.  If the name
+    // starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping
+    // rules are used to find the type (i.e. first the nested types within this
+    // message are searched, then within the parent, on up to the root
+    // namespace).
     type_name: ?ManagedString = null,
+    // For extensions, this is the name of the type being extended.  It is
+    // resolved in the same manner as type_name.
     extendee: ?ManagedString = null,
+    // For numeric types, contains the original text representation of the value.
+    // For booleans, "true" or "false".
+    // For strings, contains the default text contents (not escaped in any way).
+    // For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
     default_value: ?ManagedString = null,
+    // If set, gives the index of a oneof in the containing type's oneof_decl
+    // list.  This field is a member of that oneof.
     oneof_index: ?i32 = null,
+    // JSON name of this field. The value is set by protocol compiler. If the
+    // user has set a "json_name" option on this field, that option's value
+    // will be used. Otherwise, it's deduced from the field's name by converting
+    // it to camelCase.
     json_name: ?ManagedString = null,
     options: ?FieldOptions = null,
+    // If true, this is a proto3 "optional". When a proto3 field is optional, it
+    // tracks presence regardless of field type.
+    //
+    // When proto3_optional is true, this field must be belong to a oneof to
+    // signal to old proto3 clients that presence is tracked for this field. This
+    // oneof is known as a "synthetic" oneof, and this field must be its sole
+    // member (each proto3 optional field gets its own synthetic oneof). Synthetic
+    // oneofs exist in the descriptor only, and do not generate any API. Synthetic
+    // oneofs must be ordered after all "real" oneofs.
+    //
+    // For message fields, proto3_optional doesn't create any semantic change,
+    // since non-repeated message fields always track presence. However it still
+    // indicates the semantic detail of whether the user wrote "optional" or not.
+    // This can be useful for round-tripping the .proto file. For consistency we
+    // give message fields a synthetic oneof also, even though it is not required
+    // to track presence. This is especially important because the parser can't
+    // tell if a field is a message or an enum, so it must always create a
+    // synthetic oneof.
+    //
+    // Proto2 optional fields do not set this flag, because they already indicate
+    // optional with `LABEL_OPTIONAL`.
     proto3_optional: ?bool = null,
 
     pub const _desc_table = .{
@@ -644,7 +720,12 @@ pub const EnumDescriptorProto = struct {
     name: ?ManagedString = null,
     value: ArrayList(EnumValueDescriptorProto),
     options: ?EnumOptions = null,
+    // Range of reserved numeric values. Reserved numeric values may not be used
+    // by enum values in the same enum declaration. Reserved ranges may not
+    // overlap.
     reserved_range: ArrayList(EnumDescriptorProto.EnumReservedRange),
+    // Reserved enum value names, which may not be reused. A given name may only
+    // be reserved once.
     reserved_name: ArrayList(ManagedString),
 
     pub const _desc_table = .{
@@ -885,10 +966,14 @@ pub const ServiceDescriptorProto = struct {
 // Describes a method of a service.
 pub const MethodDescriptorProto = struct {
     name: ?ManagedString = null,
+    // Input and output type names.  These are resolved in the same way as
+    // FieldDescriptorProto.type_name, but must refer to a message type.
     input_type: ?ManagedString = null,
     output_type: ?ManagedString = null,
     options: ?MethodOptions = null,
+    // Identifies if client streams multiple client messages
     client_streaming: ?bool = false,
+    // Identifies if server streams multiple server messages
     server_streaming: ?bool = false,
 
     pub const _desc_table = .{
@@ -948,26 +1033,89 @@ pub const MethodDescriptorProto = struct {
 };
 
 pub const FileOptions = struct {
+    // Sets the Java package where classes generated from this .proto will be
+    // placed.  By default, the proto package is used, but this is often
+    // inappropriate because proto packages do not normally start with backwards
+    // domain names.
     java_package: ?ManagedString = null,
+    // Controls the name of the wrapper Java class generated for the .proto file.
+    // That class will always contain the .proto file's getDescriptor() method as
+    // well as any top-level extensions defined in the .proto file.
+    // If java_multiple_files is disabled, then all the other classes from the
+    // .proto file will be nested inside the single wrapper outer class.
     java_outer_classname: ?ManagedString = null,
+    // If enabled, then the Java code generator will generate a separate .java
+    // file for each top-level message, enum, and service defined in the .proto
+    // file.  Thus, these types will *not* be nested inside the wrapper class
+    // named by java_outer_classname.  However, the wrapper class will still be
+    // generated to contain the file's getDescriptor() method as well as any
+    // top-level extensions defined in the file.
     java_multiple_files: ?bool = false,
+    // This option does nothing.
     java_generate_equals_and_hash: ?bool = null,
+    // If set true, then the Java2 code generator will generate code that
+    // throws an exception whenever an attempt is made to assign a non-UTF-8
+    // byte sequence to a string field.
+    // Message reflection will do the same.
+    // However, an extension field still accepts non-UTF-8 byte sequences.
+    // This option has no effect on when used with the lite runtime.
     java_string_check_utf8: ?bool = false,
     optimize_for: ?FileOptions.OptimizeMode = .SPEED,
+    // Sets the Go package where structs generated from this .proto will be
+    // placed. If omitted, the Go package will be derived from the following:
+    //   - The basename of the package import path, if provided.
+    //   - Otherwise, the package statement in the .proto file, if present.
+    //   - Otherwise, the basename of the .proto file, without extension.
     go_package: ?ManagedString = null,
+    // Should generic services be generated in each language?  "Generic" services
+    // are not specific to any particular RPC system.  They are generated by the
+    // main code generators in each language (without additional plugins).
+    // Generic services were the only kind of service generation supported by
+    // early versions of google.protobuf.
+    //
+    // Generic services are now considered deprecated in favor of using plugins
+    // that generate code specific to your particular RPC system.  Therefore,
+    // these default to false.  Old code which depends on generic services should
+    // explicitly set them to true.
     cc_generic_services: ?bool = false,
     java_generic_services: ?bool = false,
     py_generic_services: ?bool = false,
     php_generic_services: ?bool = false,
+    // Is this file deprecated?
+    // Depending on the target platform, this can emit Deprecated annotations
+    // for everything in the file, or it will be completely ignored; in the very
+    // least, this is a formalization for deprecating files.
     deprecated: ?bool = false,
+    // Enables the use of arenas for the proto messages in this file. This applies
+    // only to generated classes for C++.
     cc_enable_arenas: ?bool = true,
+    // Sets the objective c class prefix which is prepended to all objective c
+    // generated classes from this .proto. There is no default.
     objc_class_prefix: ?ManagedString = null,
+    // Namespace for generated classes; defaults to the package.
     csharp_namespace: ?ManagedString = null,
+    // By default Swift generators will take the proto package and CamelCase it
+    // replacing '.' with underscore and use that to prefix the types/symbols
+    // defined. When this options is provided, they will use this value instead
+    // to prefix the types/symbols defined.
     swift_prefix: ?ManagedString = null,
+    // Sets the php class prefix which is prepended to all php generated classes
+    // from this .proto. Default is empty.
     php_class_prefix: ?ManagedString = null,
+    // Use this option to change the namespace of php generated classes. Default
+    // is empty. When this option is empty, the package name will be used for
+    // determining the namespace.
     php_namespace: ?ManagedString = null,
+    // Use this option to change the namespace of php generated metadata classes.
+    // Default is empty. When this option is empty, the proto file name will be
+    // used for determining the namespace.
     php_metadata_namespace: ?ManagedString = null,
+    // Use this option to change the package of ruby generated classes. Default
+    // is empty. When this option is not set, the package name will be used for
+    // determining the ruby package.
     ruby_package: ?ManagedString = null,
+    // The parser stores options it doesn't recognize here.
+    // See the documentation for the "Options" section above.
     uninterpreted_option: ArrayList(UninterpretedOption),
 
     pub const _desc_table = .{
@@ -1051,11 +1199,68 @@ pub const FileOptions = struct {
 };
 
 pub const MessageOptions = struct {
+    // Set true to use the old proto1 MessageSet wire format for extensions.
+    // This is provided for backwards-compatibility with the MessageSet wire
+    // format.  You should not use this for any other reason:  It's less
+    // efficient, has fewer features, and is more complicated.
+    //
+    // The message must be defined exactly as follows:
+    //   message Foo {
+    //     option message_set_wire_format = true;
+    //     extensions 4 to max;
+    //   }
+    // Note that the message cannot have any defined fields; MessageSets only
+    // have extensions.
+    //
+    // All extensions of your type must be singular messages; e.g. they cannot
+    // be int32s, enums, or repeated messages.
+    //
+    // Because this is an option, the above two restrictions are not enforced by
+    // the protocol compiler.
     message_set_wire_format: ?bool = false,
+    // Disables the generation of the standard "descriptor()" accessor, which can
+    // conflict with a field of the same name.  This is meant to make migration
+    // from proto1 easier; new code should avoid fields named "descriptor".
     no_standard_descriptor_accessor: ?bool = false,
+    // Is this message deprecated?
+    // Depending on the target platform, this can emit Deprecated annotations
+    // for the message, or it will be completely ignored; in the very least,
+    // this is a formalization for deprecating messages.
     deprecated: ?bool = false,
+    // NOTE: Do not set the option in .proto files. Always use the maps syntax
+    // instead. The option should only be implicitly set by the proto compiler
+    // parser.
+    //
+    // Whether the message is an automatically generated map entry type for the
+    // maps field.
+    //
+    // For maps fields:
+    //     map<KeyType, ValueType> map_field = 1;
+    // The parsed descriptor looks like:
+    //     message MapFieldEntry {
+    //         option map_entry = true;
+    //         optional KeyType key = 1;
+    //         optional ValueType value = 2;
+    //     }
+    //     repeated MapFieldEntry map_field = 1;
+    //
+    // Implementations may choose not to generate the map_entry=true message, but
+    // use a native map in the target language to hold the keys and values.
+    // The reflection APIs in such implementations still need to work as
+    // if the field is a repeated message field.
     map_entry: ?bool = null,
+    // Enable the legacy handling of JSON field name conflicts.  This lowercases
+    // and strips underscored from the fields before comparison in proto3 only.
+    // The new behavior takes `json_name` into account and applies to proto2 as
+    // well.
+    //
+    // This should only be used as a temporary measure against broken builds due
+    // to the change in behavior for JSON field name conflicts.
+    //
+    // TODO(b/261750190) This is legacy behavior we plan to remove once downstream
+    // teams have had time to migrate.
     deprecated_legacy_json_field_conflicts: ?bool = null,
+    // The parser stores options it doesn't recognize here. See above.
     uninterpreted_option: ArrayList(UninterpretedOption),
 
     pub const _desc_table = .{
@@ -1115,17 +1320,80 @@ pub const MessageOptions = struct {
 };
 
 pub const FieldOptions = struct {
+    // The ctype option instructs the C++ code generator to use a different
+    // representation of the field than it normally would.  See the specific
+    // options below.  This option is only implemented to support use of
+    // [ctype=CORD] and [ctype=STRING] (the default) on non-repeated fields of
+    // type "bytes" in the open source release -- sorry, we'll try to include
+    // other types in a future version!
     ctype: ?FieldOptions.CType = .STRING,
+    // The packed option can be enabled for repeated primitive fields to enable
+    // a more efficient representation on the wire. Rather than repeatedly
+    // writing the tag and type for each element, the entire array is encoded as
+    // a single length-delimited blob. In proto3, only explicit setting it to
+    // false will avoid using packed encoding.
     @"packed": ?bool = null,
+    // The jstype option determines the JavaScript type used for values of the
+    // field.  The option is permitted only for 64 bit integral and fixed types
+    // (int64, uint64, sint64, fixed64, sfixed64).  A field with jstype JS_STRING
+    // is represented as JavaScript string, which avoids loss of precision that
+    // can happen when a large value is converted to a floating point JavaScript.
+    // Specifying JS_NUMBER for the jstype causes the generated JavaScript code to
+    // use the JavaScript "number" type.  The behavior of the default option
+    // JS_NORMAL is implementation dependent.
+    //
+    // This option is an enum to permit additional types to be added, e.g.
+    // goog.math.Integer.
     jstype: ?FieldOptions.JSType = .JS_NORMAL,
+    // Should this field be parsed lazily?  Lazy applies only to message-type
+    // fields.  It means that when the outer message is initially parsed, the
+    // inner message's contents will not be parsed but instead stored in encoded
+    // form.  The inner message will actually be parsed when it is first accessed.
+    //
+    // This is only a hint.  Implementations are free to choose whether to use
+    // eager or lazy parsing regardless of the value of this option.  However,
+    // setting this option true suggests that the protocol author believes that
+    // using lazy parsing on this field is worth the additional bookkeeping
+    // overhead typically needed to implement it.
+    //
+    // This option does not affect the public interface of any generated code;
+    // all method signatures remain the same.  Furthermore, thread-safety of the
+    // interface is not affected by this option; const methods remain safe to
+    // call from multiple threads concurrently, while non-const methods continue
+    // to require exclusive access.
+    //
+    // Note that implementations may choose not to check required fields within
+    // a lazy sub-message.  That is, calling IsInitialized() on the outer message
+    // may return true even if the inner message has missing required fields.
+    // This is necessary because otherwise the inner message would have to be
+    // parsed in order to perform the check, defeating the purpose of lazy
+    // parsing.  An implementation which chooses not to check required fields
+    // must be consistent about it.  That is, for any particular sub-message, the
+    // implementation must either *always* check its required fields, or *never*
+    // check its required fields, regardless of whether or not the message has
+    // been parsed.
+    //
+    // As of May 2022, lazy verifies the contents of the byte stream during
+    // parsing.  An invalid byte stream will cause the overall parsing to fail.
     lazy: ?bool = false,
+    // unverified_lazy does no correctness checks on the byte stream. This should
+    // only be used where lazy with verification is prohibitive for performance
+    // reasons.
     unverified_lazy: ?bool = false,
+    // Is this field deprecated?
+    // Depending on the target platform, this can emit Deprecated annotations
+    // for accessors, or it will be completely ignored; in the very least, this
+    // is a formalization for deprecating fields.
     deprecated: ?bool = false,
+    // For Google-internal migration only. Do not use.
     weak: ?bool = false,
+    // Indicate that the field value should not be printed out when using debug
+    // formats, e.g. when the field contains sensitive credentials.
     debug_redact: ?bool = false,
     retention: ?FieldOptions.OptionRetention = null,
     target: ?FieldOptions.OptionTargetType = null,
     targets: ArrayList(FieldOptions.OptionTargetType),
+    // The parser stores options it doesn't recognize here. See above.
     uninterpreted_option: ArrayList(UninterpretedOption),
 
     pub const _desc_table = .{
@@ -1243,6 +1511,7 @@ pub const FieldOptions = struct {
 };
 
 pub const OneofOptions = struct {
+    // The parser stores options it doesn't recognize here. See above.
     uninterpreted_option: ArrayList(UninterpretedOption),
 
     pub const _desc_table = .{
@@ -1297,9 +1566,22 @@ pub const OneofOptions = struct {
 };
 
 pub const EnumOptions = struct {
+    // Set this option to true to allow mapping different tag names to the same
+    // value.
     allow_alias: ?bool = null,
+    // Is this enum deprecated?
+    // Depending on the target platform, this can emit Deprecated annotations
+    // for the enum, or it will be completely ignored; in the very least, this
+    // is a formalization for deprecating enums.
     deprecated: ?bool = false,
+    // Enable the legacy handling of JSON field name conflicts.  This lowercases
+    // and strips underscored from the fields before comparison in proto3 only.
+    // The new behavior takes `json_name` into account and applies to proto2 as
+    // well.
+    // TODO(b/261750190) Remove this legacy behavior once downstream teams have
+    // had time to migrate.
     deprecated_legacy_json_field_conflicts: ?bool = null,
+    // The parser stores options it doesn't recognize here. See above.
     uninterpreted_option: ArrayList(UninterpretedOption),
 
     pub const _desc_table = .{
@@ -1357,7 +1639,12 @@ pub const EnumOptions = struct {
 };
 
 pub const EnumValueOptions = struct {
+    // Is this enum value deprecated?
+    // Depending on the target platform, this can emit Deprecated annotations
+    // for the enum value, or it will be completely ignored; in the very least,
+    // this is a formalization for deprecating enum values.
     deprecated: ?bool = false,
+    // The parser stores options it doesn't recognize here. See above.
     uninterpreted_option: ArrayList(UninterpretedOption),
 
     pub const _desc_table = .{
@@ -1413,7 +1700,12 @@ pub const EnumValueOptions = struct {
 };
 
 pub const ServiceOptions = struct {
+    // Is this service deprecated?
+    // Depending on the target platform, this can emit Deprecated annotations
+    // for the service, or it will be completely ignored; in the very least,
+    // this is a formalization for deprecating services.
     deprecated: ?bool = false,
+    // The parser stores options it doesn't recognize here. See above.
     uninterpreted_option: ArrayList(UninterpretedOption),
 
     pub const _desc_table = .{
@@ -1469,8 +1761,13 @@ pub const ServiceOptions = struct {
 };
 
 pub const MethodOptions = struct {
+    // Is this method deprecated?
+    // Depending on the target platform, this can emit Deprecated annotations
+    // for the method, or it will be completely ignored; in the very least,
+    // this is a formalization for deprecating methods.
     deprecated: ?bool = false,
     idempotency_level: ?MethodOptions.IdempotencyLevel = .IDEMPOTENCY_UNKNOWN,
+    // The parser stores options it doesn't recognize here. See above.
     uninterpreted_option: ArrayList(UninterpretedOption),
 
     pub const _desc_table = .{
@@ -1544,6 +1841,8 @@ pub const MethodOptions = struct {
 // in them.
 pub const UninterpretedOption = struct {
     name: ArrayList(UninterpretedOption.NamePart),
+    // The value of the uninterpreted option, in whatever type the tokenizer
+    // identified it as during parsing. Exactly one of these should be set.
     identifier_value: ?ManagedString = null,
     positive_int_value: ?u64 = null,
     negative_int_value: ?i64 = null,
@@ -1672,6 +1971,49 @@ pub const UninterpretedOption = struct {
 // Encapsulates information about the original source file from which a
 // FileDescriptorProto was generated.
 pub const SourceCodeInfo = struct {
+    // A Location identifies a piece of source code in a .proto file which
+    // corresponds to a particular definition.  This information is intended
+    // to be useful to IDEs, code indexers, documentation generators, and similar
+    // tools.
+    //
+    // For example, say we have a file like:
+    //   message Foo {
+    //     optional string foo = 1;
+    //   }
+    // Let's look at just the field definition:
+    //   optional string foo = 1;
+    //   ^       ^^     ^^  ^  ^^^
+    //   a       bc     de  f  ghi
+    // We have the following locations:
+    //   span   path               represents
+    //   [a,i)  [ 4, 0, 2, 0 ]     The whole field definition.
+    //   [a,b)  [ 4, 0, 2, 0, 4 ]  The label (optional).
+    //   [c,d)  [ 4, 0, 2, 0, 5 ]  The type (string).
+    //   [e,f)  [ 4, 0, 2, 0, 1 ]  The name (foo).
+    //   [g,h)  [ 4, 0, 2, 0, 3 ]  The number (1).
+    //
+    // Notes:
+    // - A location may refer to a repeated field itself (i.e. not to any
+    //   particular index within it).  This is used whenever a set of elements are
+    //   logically enclosed in a single code segment.  For example, an entire
+    //   extend block (possibly containing multiple extension definitions) will
+    //   have an outer location whose path refers to the "extensions" repeated
+    //   field without an index.
+    // - Multiple locations may have the same path.  This happens when a single
+    //   logical declaration is spread out across multiple places.  The most
+    //   obvious example is the "extend" block again -- there may be multiple
+    //   extend blocks in the same scope, each of which will have the same path.
+    // - A location's span is not always a subset of its parent's span.  For
+    //   example, the "extendee" of an extension declaration appears at the
+    //   beginning of the "extend" block and is shared by all extensions within
+    //   the block.
+    // - Just because a location's span is a subset of some other location's span
+    //   does not mean that it is a descendant.  For example, a "group" defines
+    //   both a type and a field in a single declaration.  Thus, the locations
+    //   corresponding to the type and field and their components will overlap.
+    // - Code which tries to interpret locations should probably be designed to
+    //   ignore those that it doesn't understand, as more types of locations could
+    //   be recorded in the future.
     location: ArrayList(SourceCodeInfo.Location),
 
     pub const _desc_table = .{
@@ -1679,8 +2021,83 @@ pub const SourceCodeInfo = struct {
     };
 
     pub const Location = struct {
+        // Identifies which part of the FileDescriptorProto was defined at this
+        // location.
+        //
+        // Each element is a field number or an index.  They form a path from
+        // the root FileDescriptorProto to the place where the definition occurs.
+        // For example, this path:
+        //   [ 4, 3, 2, 7, 1 ]
+        // refers to:
+        //   file.message_type(3)  // 4, 3
+        //       .field(7)         // 2, 7
+        //       .name()           // 1
+        // This is because FileDescriptorProto.message_type has field number 4:
+        //   repeated DescriptorProto message_type = 4;
+        // and DescriptorProto.field has field number 2:
+        //   repeated FieldDescriptorProto field = 2;
+        // and FieldDescriptorProto.name has field number 1:
+        //   optional string name = 1;
+        //
+        // Thus, the above path gives the location of a field name.  If we removed
+        // the last element:
+        //   [ 4, 3, 2, 7 ]
+        // this path refers to the whole field declaration (from the beginning
+        // of the label to the terminating semicolon).
         path: ArrayList(i32),
+        // Always has exactly three or four elements: start line, start column,
+        // end line (optional, otherwise assumed same as start line), end column.
+        // These are packed into a single field for efficiency.  Note that line
+        // and column numbers are zero-based -- typically you will want to add
+        // 1 to each before displaying to a user.
         span: ArrayList(i32),
+        // If this SourceCodeInfo represents a complete declaration, these are any
+        // comments appearing before and after the declaration which appear to be
+        // attached to the declaration.
+        //
+        // A series of line comments appearing on consecutive lines, with no other
+        // tokens appearing on those lines, will be treated as a single comment.
+        //
+        // leading_detached_comments will keep paragraphs of comments that appear
+        // before (but not connected to) the current element. Each paragraph,
+        // separated by empty lines, will be one comment element in the repeated
+        // field.
+        //
+        // Only the comment content is provided; comment markers (e.g. //) are
+        // stripped out.  For block comments, leading whitespace and an asterisk
+        // will be stripped from the beginning of each line other than the first.
+        // Newlines are included in the output.
+        //
+        // Examples:
+        //
+        //   optional int32 foo = 1;  // Comment attached to foo.
+        //   // Comment attached to bar.
+        //   optional int32 bar = 2;
+        //
+        //   optional string baz = 3;
+        //   // Comment attached to baz.
+        //   // Another line attached to baz.
+        //
+        //   // Comment attached to moo.
+        //   //
+        //   // Another line attached to moo.
+        //   optional double moo = 4;
+        //
+        //   // Detached comment for corge. This is not leading or trailing comments
+        //   // to moo or corge because there are blank lines separating it from
+        //   // both.
+        //
+        //   // Detached comment for corge paragraph 2.
+        //
+        //   optional string corge = 5;
+        //   /* Block comment attached
+        //    * to corge.  Leading asterisks
+        //    * will be removed. */
+        //   /* Block comment attached to
+        //    * grault. */
+        //   optional int32 grault = 6;
+        //
+        //   // ignored detached comments.
         leading_comments: ?ManagedString = null,
         trailing_comments: ?ManagedString = null,
         leading_detached_comments: ArrayList(ManagedString),
@@ -1791,6 +2208,8 @@ pub const SourceCodeInfo = struct {
 // file. A GeneratedCodeInfo message is associated with only one generated
 // source file, but may contain references to different source .proto files.
 pub const GeneratedCodeInfo = struct {
+    // An Annotation connects some span of text in generated code to an element
+    // of its generating .proto file.
     annotation: ArrayList(GeneratedCodeInfo.Annotation),
 
     pub const _desc_table = .{
@@ -1798,9 +2217,17 @@ pub const GeneratedCodeInfo = struct {
     };
 
     pub const Annotation = struct {
+        // Identifies the element in the original source .proto file. This field
+        // is formatted the same as SourceCodeInfo.Location.path.
         path: ArrayList(i32),
+        // Identifies the filesystem path to the original source .proto.
         source_file: ?ManagedString = null,
+        // Identifies the starting offset in bytes in the generated code
+        // that relates to the identified object.
         begin: ?i32 = null,
+        // Identifies the ending offset in bytes in the generated code that
+        // relates to the identified object. The end offset should be one past
+        // the last relevant byte (so the length of the text = end - begin).
         end: ?i32 = null,
         semantic: ?GeneratedCodeInfo.Annotation.Semantic = null,
 
@@ -2004,7 +2431,35 @@ pub const GeneratedCodeInfo = struct {
 //       "value": "1.212s"
 //     }
 pub const Any = struct {
+    // A URL/resource name that uniquely identifies the type of the serialized
+    // protocol buffer message. This string must contain at least
+    // one "/" character. The last segment of the URL's path must represent
+    // the fully qualified name of the type (as in
+    // `path/google.protobuf.Duration`). The name should be in a canonical form
+    // (e.g., leading "." is not accepted).
+    //
+    // In practice, teams usually precompile into the binary all types that they
+    // expect it to use in the context of Any. However, for URLs which use the
+    // scheme `http`, `https`, or no scheme, one can optionally set up a type
+    // server that maps type URLs to message definitions as follows:
+    //
+    // * If no scheme is provided, `https` is assumed.
+    // * An HTTP GET on the URL must yield a [google.protobuf.Type][]
+    //   value in binary format, or produce an error.
+    // * Applications are allowed to cache lookup results based on the
+    //   URL, or have them precompiled into a binary to avoid any
+    //   lookup. Therefore, binary compatibility needs to be preserved
+    //   on changes to types. (Use versioned type names to manage
+    //   breaking changes.)
+    //
+    // Note: this functionality is not currently available in the official
+    // protobuf release, and it is not used for type URLs beginning with
+    // type.googleapis.com.
+    //
+    // Schemes other than `http`, `https` (or the empty scheme) might be
+    // used with implementation specific semantics.
     type_url: ManagedString = .Empty,
+    // Must be a valid serialized protocol buffer of the above specified type.
     value: ManagedString = .Empty,
 
     pub const _desc_table = .{
@@ -2118,7 +2573,16 @@ pub const Any = struct {
 // be expressed in JSON format as "3.000000001s", and 3 seconds and 1
 // microsecond should be expressed in JSON format as "3.000001s".
 pub const Duration = struct {
+    // Signed seconds of the span of time. Must be from -315,576,000,000
+    // to +315,576,000,000 inclusive. Note: these bounds are computed from:
+    // 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
     seconds: i64 = 0,
+    // Signed fractions of a second at nanosecond resolution of the span
+    // of time. Durations less than one second are represented with a 0
+    // `seconds` field and a positive or negative `nanos` field. For durations
+    // of one second or more, a non-zero value for the `nanos` field must be
+    // of the same sign as the `seconds` field. Must be from -999,999,999
+    // to +999,999,999 inclusive.
     nanos: i32 = 0,
 
     pub const _desc_table = .{
@@ -2373,6 +2837,7 @@ pub const Duration = struct {
 // request should verify the included field paths, and return an
 // `INVALID_ARGUMENT` error if any path is unmappable.
 pub const FieldMask = struct {
+    // The set of field mask paths.
     paths: ArrayList(ManagedString),
 
     pub const _desc_table = .{
@@ -2445,6 +2910,7 @@ pub const NullValue = enum(i32) {
 //
 // The JSON representation for `Struct` is JSON object.
 pub const Struct = struct {
+    // Unordered map of dynamically typed values.
     fields: ArrayList(Struct.FieldsEntry),
 
     pub const _desc_table = .{
@@ -2561,6 +3027,7 @@ pub const Struct = struct {
 //
 // The JSON representation for `Value` is JSON value.
 pub const Value = struct {
+    // The kind of value.
     kind: ?kind_union,
 
     pub const _kind_case = enum {
@@ -2572,11 +3039,17 @@ pub const Value = struct {
         list_value,
     };
     pub const kind_union = union(_kind_case) {
+        // Represents a null value.
         null_value: NullValue,
+        // Represents a double value.
         number_value: f64,
+        // Represents a string value.
         string_value: ManagedString,
+        // Represents a boolean value.
         bool_value: bool,
+        // Represents a structured value.
         struct_value: Struct,
+        // Represents a repeated `Value`.
         list_value: ListValue,
         pub const _union_desc = .{
             .null_value = fd(1, .{ .Varint = .Simple }),
@@ -2643,6 +3116,7 @@ pub const Value = struct {
 //
 // The JSON representation for `ListValue` is JSON array.
 pub const ListValue = struct {
+    // Repeated field of dynamically typed values.
     values: ArrayList(Value),
 
     pub const _desc_table = .{
@@ -2786,7 +3260,14 @@ pub const ListValue = struct {
 // http://joda-time.sourceforge.net/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime()
 // ) to obtain a formatter capable of generating timestamps in this format.
 pub const Timestamp = struct {
+    // Represents seconds of UTC time since Unix epoch
+    // 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+    // 9999-12-31T23:59:59Z inclusive.
     seconds: i64 = 0,
+    // Non-negative fractions of a second at nanosecond resolution. Negative
+    // second values with fractions must still have non-negative nanos values
+    // that count forward in time. Must be from 0 to 999,999,999
+    // inclusive.
     nanos: i32 = 0,
 
     pub const _desc_table = .{
@@ -2845,6 +3326,7 @@ pub const Timestamp = struct {
 //
 // The JSON representation for `DoubleValue` is JSON number.
 pub const DoubleValue = struct {
+    // The double value.
     value: f64 = 0,
 
     pub const _desc_table = .{
@@ -2902,6 +3384,7 @@ pub const DoubleValue = struct {
 //
 // The JSON representation for `FloatValue` is JSON number.
 pub const FloatValue = struct {
+    // The float value.
     value: f32 = 0,
 
     pub const _desc_table = .{
@@ -2959,6 +3442,7 @@ pub const FloatValue = struct {
 //
 // The JSON representation for `Int64Value` is JSON string.
 pub const Int64Value = struct {
+    // The int64 value.
     value: i64 = 0,
 
     pub const _desc_table = .{
@@ -3016,6 +3500,7 @@ pub const Int64Value = struct {
 //
 // The JSON representation for `UInt64Value` is JSON string.
 pub const UInt64Value = struct {
+    // The uint64 value.
     value: u64 = 0,
 
     pub const _desc_table = .{
@@ -3073,6 +3558,7 @@ pub const UInt64Value = struct {
 //
 // The JSON representation for `Int32Value` is JSON number.
 pub const Int32Value = struct {
+    // The int32 value.
     value: i32 = 0,
 
     pub const _desc_table = .{
@@ -3130,6 +3616,7 @@ pub const Int32Value = struct {
 //
 // The JSON representation for `UInt32Value` is JSON number.
 pub const UInt32Value = struct {
+    // The uint32 value.
     value: u32 = 0,
 
     pub const _desc_table = .{
@@ -3187,6 +3674,7 @@ pub const UInt32Value = struct {
 //
 // The JSON representation for `BoolValue` is JSON `true` and `false`.
 pub const BoolValue = struct {
+    // The bool value.
     value: bool = false,
 
     pub const _desc_table = .{
@@ -3244,6 +3732,7 @@ pub const BoolValue = struct {
 //
 // The JSON representation for `StringValue` is JSON string.
 pub const StringValue = struct {
+    // The string value.
     value: ManagedString = .Empty,
 
     pub const _desc_table = .{
@@ -3301,6 +3790,7 @@ pub const StringValue = struct {
 //
 // The JSON representation for `BytesValue` is JSON string.
 pub const BytesValue = struct {
+    // The bytes value.
     value: ManagedString = .Empty,
 
     pub const _desc_table = .{

--- a/tests/generated/graphics.pb.zig
+++ b/tests/generated/graphics.pb.zig
@@ -952,6 +952,7 @@ pub const MapItem = struct {
 pub const GraphicsDB = struct {
     textures: ArrayList(Texture),
     graphics: ArrayList(Graphic),
+    // repeated Tileset tilesets = 3;
     bodies: ArrayList(Index),
     fxs: ArrayList(Index),
     heads: ArrayList(Index),

--- a/tests/generated/jspb/test.pb.zig
+++ b/tests/generated/jspb/test.pb.zig
@@ -247,6 +247,7 @@ pub const Simple2 = struct {
 
 pub const SpecialCases = struct {
     normal: ManagedString,
+    // Examples of Js reserved names that are converted to pb_<name>.
     default: ManagedString,
     function: ManagedString,
     @"var": ManagedString,
@@ -954,6 +955,29 @@ pub const CloneExtension = struct {
 };
 
 pub const TestGroup = struct {
+    // repeated group RepeatedGroup = 1 {
+    //   required string id = 1;
+    //   repeated bool some_bool = 2;
+    // }
+    // required group RequiredGroup = 2 {
+    //   required string id = 1;
+    // }
+    // optional group OptionalGroup = 3 {
+    //   required string id = 1;
+    // }
+    // optional group MessageInGroup = 4 {
+    //   message NestedMessage {
+    //     optional string id = 1;
+    //   }
+    //   required NestedMessage id = 1;
+    // }
+    // optional group EnumInGroup = 5 {
+    //   enum NestedEnum {
+    //     first = 0;
+    //     second = 1;
+    //   }
+    //   required NestedEnum id = 1;
+    // }
     id: ?ManagedString = null,
     required_simple: ?Simple2 = null,
     optional_simple: ?Simple2 = null,

--- a/tests/generated/jspb/test.pb.zig
+++ b/tests/generated/jspb/test.pb.zig
@@ -188,6 +188,7 @@ pub const Simple1 = struct {
     }
 };
 
+// A message that differs from Simple1 only by name
 pub const Simple2 = struct {
     a_string: ManagedString,
     a_repeated_string: ArrayList(ManagedString),

--- a/tests/generated/opentelemetry/proto/common/v1.pb.zig
+++ b/tests/generated/opentelemetry/proto/common/v1.pb.zig
@@ -11,6 +11,9 @@ const ManagedStruct = protobuf.ManagedStruct;
 const json = protobuf.json;
 const UnionDecodingError = protobuf.UnionDecodingError;
 
+// AnyValue is used to represent any type of attribute value. AnyValue may contain a
+// primitive value such as a string or integer or it may contain an arbitrary nested
+// object containing arrays, key-value lists and primitives.
 pub const AnyValue = struct {
     value: ?value_union,
 
@@ -93,6 +96,8 @@ pub const AnyValue = struct {
     }
 };
 
+// ArrayValue is a list of AnyValue messages. We need ArrayValue as a message
+// since oneof in AnyValue does not allow repeated fields.
 pub const ArrayValue = struct {
     values: ArrayList(AnyValue),
 
@@ -147,6 +152,11 @@ pub const ArrayValue = struct {
     }
 };
 
+// KeyValueList is a list of KeyValue messages. We need KeyValueList as a message
+// since `oneof` in AnyValue does not allow repeated fields. Everywhere else where we need
+// a list of KeyValue messages (e.g. in Span) we use `repeated KeyValue` directly to
+// avoid unnecessary extra wrapping (which slows down the protocol). The 2 approaches
+// are semantically equivalent.
 pub const KeyValueList = struct {
     values: ArrayList(KeyValue),
 
@@ -201,6 +211,8 @@ pub const KeyValueList = struct {
     }
 };
 
+// KeyValue is a key-value pair that is used to store Span attributes, Link
+// attributes, etc.
 pub const KeyValue = struct {
     key: ManagedString = .Empty,
     value: ?AnyValue = null,
@@ -257,6 +269,8 @@ pub const KeyValue = struct {
     }
 };
 
+// InstrumentationScope is a message representing the instrumentation scope information
+// such as the fully qualified name and version.
 pub const InstrumentationScope = struct {
     name: ManagedString = .Empty,
     version: ManagedString = .Empty,

--- a/tests/generated/opentelemetry/proto/common/v1.pb.zig
+++ b/tests/generated/opentelemetry/proto/common/v1.pb.zig
@@ -15,6 +15,8 @@ const UnionDecodingError = protobuf.UnionDecodingError;
 // primitive value such as a string or integer or it may contain an arbitrary nested
 // object containing arrays, key-value lists and primitives.
 pub const AnyValue = struct {
+    // The value is one of the listed fields. It is valid for all values to be unspecified
+    // in which case this AnyValue is considered to be "empty".
     value: ?value_union,
 
     pub const _value_case = enum {
@@ -99,6 +101,7 @@ pub const AnyValue = struct {
 // ArrayValue is a list of AnyValue messages. We need ArrayValue as a message
 // since oneof in AnyValue does not allow repeated fields.
 pub const ArrayValue = struct {
+    // Array of values. The array may be empty (contain 0 elements).
     values: ArrayList(AnyValue),
 
     pub const _desc_table = .{
@@ -158,6 +161,10 @@ pub const ArrayValue = struct {
 // avoid unnecessary extra wrapping (which slows down the protocol). The 2 approaches
 // are semantically equivalent.
 pub const KeyValueList = struct {
+    // A collection of key/value pairs of key-value pairs. The list may be empty (may
+    // contain 0 elements).
+    // The keys MUST be unique (it is not allowed to have more than one
+    // value with the same key).
     values: ArrayList(KeyValue),
 
     pub const _desc_table = .{
@@ -272,8 +279,12 @@ pub const KeyValue = struct {
 // InstrumentationScope is a message representing the instrumentation scope information
 // such as the fully qualified name and version.
 pub const InstrumentationScope = struct {
+    // An empty instrumentation scope name means the name is unknown.
     name: ManagedString = .Empty,
     version: ManagedString = .Empty,
+    // Additional attributes that describe the scope. [Optional].
+    // Attribute keys MUST be unique (it is not allowed to have more than one
+    // attribute with the same key).
     attributes: ArrayList(KeyValue),
     dropped_attributes_count: u32 = 0,
 

--- a/tests/generated/opentelemetry/proto/logs/v1.pb.zig
+++ b/tests/generated/opentelemetry/proto/logs/v1.pb.zig
@@ -15,7 +15,9 @@ const opentelemetry_proto_common_v1 = @import("../common/v1.pb.zig");
 /// import package opentelemetry.proto.resource.v1
 const opentelemetry_proto_resource_v1 = @import("../resource/v1.pb.zig");
 
+// Possible values for LogRecord.SeverityNumber.
 pub const SeverityNumber = enum(i32) {
+    // UNSPECIFIED is the default SeverityNumber, it MUST NOT be used.
     SEVERITY_NUMBER_UNSPECIFIED = 0,
     SEVERITY_NUMBER_TRACE = 1,
     SEVERITY_NUMBER_TRACE2 = 2,
@@ -44,12 +46,32 @@ pub const SeverityNumber = enum(i32) {
     _,
 };
 
+// LogRecordFlags represents constants used to interpret the
+// LogRecord.flags field, which is protobuf 'fixed32' type and is to
+// be used as bit-fields. Each non-zero value defined in this enum is
+// a bit-mask.  To extract the bit-field, for example, use an
+// expression like:
+//
+//   (logRecord.flags & LOG_RECORD_FLAGS_TRACE_FLAGS_MASK)
 pub const LogRecordFlags = enum(i32) {
+    // The zero value for the enum. Should not be used for comparisons.
+    // Instead use bitwise "and" with the appropriate mask as shown above.
     LOG_RECORD_FLAGS_DO_NOT_USE = 0,
+    // Bits 0-7 are used for trace flags.
     LOG_RECORD_FLAGS_TRACE_FLAGS_MASK = 255,
     _,
 };
 
+// LogsData represents the logs data that can be stored in a persistent storage,
+// OR can be embedded by other protocols that transfer OTLP logs data but do not
+// implement the OTLP protocol.
+//
+// The main difference between this message and collector protocol is that
+// in this message there will not be any "control" or "metadata" specific to
+// OTLP protocol.
+//
+// When new fields are added into this message, the OTLP request MUST be updated
+// as well.
 pub const LogsData = struct {
     resource_logs: ArrayList(ResourceLogs),
 
@@ -104,6 +126,7 @@ pub const LogsData = struct {
     }
 };
 
+// A collection of ScopeLogs from a Resource.
 pub const ResourceLogs = struct {
     resource: ?opentelemetry_proto_resource_v1.Resource = null,
     scope_logs: ArrayList(ScopeLogs),
@@ -162,6 +185,7 @@ pub const ResourceLogs = struct {
     }
 };
 
+// A collection of Logs produced by a Scope.
 pub const ScopeLogs = struct {
     scope: ?opentelemetry_proto_common_v1.InstrumentationScope = null,
     log_records: ArrayList(LogRecord),
@@ -220,6 +244,8 @@ pub const ScopeLogs = struct {
     }
 };
 
+// A log record according to OpenTelemetry Log Data Model:
+// https://github.com/open-telemetry/oteps/blob/main/text/logs/0097-log-data-model.md
 pub const LogRecord = struct {
     time_unix_nano: u64 = 0,
     observed_time_unix_nano: u64 = 0,

--- a/tests/generated/opentelemetry/proto/logs/v1.pb.zig
+++ b/tests/generated/opentelemetry/proto/logs/v1.pb.zig
@@ -73,6 +73,11 @@ pub const LogRecordFlags = enum(i32) {
 // When new fields are added into this message, the OTLP request MUST be updated
 // as well.
 pub const LogsData = struct {
+    // An array of ResourceLogs.
+    // For data coming from a single resource this array will typically contain
+    // one element. Intermediary nodes that receive data from multiple origins
+    // typically batch the data before forwarding further and in that case this
+    // array will contain multiple elements.
     resource_logs: ArrayList(ResourceLogs),
 
     pub const _desc_table = .{
@@ -128,8 +133,16 @@ pub const LogsData = struct {
 
 // A collection of ScopeLogs from a Resource.
 pub const ResourceLogs = struct {
+    // The resource for the logs in this message.
+    // If this field is not set then resource info is unknown.
     resource: ?opentelemetry_proto_resource_v1.Resource = null,
+    // A list of ScopeLogs that originate from a resource.
     scope_logs: ArrayList(ScopeLogs),
+    // The Schema URL, if known. This is the identifier of the Schema that the resource data
+    // is recorded in. To learn more about Schema URL see
+    // https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
+    // This schema_url applies to the data in the "resource" field. It does not apply
+    // to the data in the "scope_logs" field which have their own schema_url field.
     schema_url: ManagedString = .Empty,
 
     pub const _desc_table = .{
@@ -187,8 +200,16 @@ pub const ResourceLogs = struct {
 
 // A collection of Logs produced by a Scope.
 pub const ScopeLogs = struct {
+    // The instrumentation scope information for the logs in this message.
+    // Semantically when InstrumentationScope isn't set, it is equivalent with
+    // an empty instrumentation scope name (unknown).
     scope: ?opentelemetry_proto_common_v1.InstrumentationScope = null,
+    // A list of log records.
     log_records: ArrayList(LogRecord),
+    // The Schema URL, if known. This is the identifier of the Schema that the log data
+    // is recorded in. To learn more about Schema URL see
+    // https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
+    // This schema_url applies to all logs in the "logs" field.
     schema_url: ManagedString = .Empty,
 
     pub const _desc_table = .{
@@ -247,15 +268,71 @@ pub const ScopeLogs = struct {
 // A log record according to OpenTelemetry Log Data Model:
 // https://github.com/open-telemetry/oteps/blob/main/text/logs/0097-log-data-model.md
 pub const LogRecord = struct {
+    // time_unix_nano is the time when the event occurred.
+    // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
+    // Value of 0 indicates unknown or missing timestamp.
     time_unix_nano: u64 = 0,
+    // Time when the event was observed by the collection system.
+    // For events that originate in OpenTelemetry (e.g. using OpenTelemetry Logging SDK)
+    // this timestamp is typically set at the generation time and is equal to Timestamp.
+    // For events originating externally and collected by OpenTelemetry (e.g. using
+    // Collector) this is the time when OpenTelemetry's code observed the event measured
+    // by the clock of the OpenTelemetry code. This field MUST be set once the event is
+    // observed by OpenTelemetry.
+    //
+    // For converting OpenTelemetry log data to formats that support only one timestamp or
+    // when receiving OpenTelemetry log data by recipients that support only one timestamp
+    // internally the following logic is recommended:
+    //   - Use time_unix_nano if it is present, otherwise use observed_time_unix_nano.
+    //
+    // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
+    // Value of 0 indicates unknown or missing timestamp.
     observed_time_unix_nano: u64 = 0,
+    // Numerical value of the severity, normalized to values described in Log Data Model.
+    // [Optional].
     severity_number: SeverityNumber = @enumFromInt(0),
+    // The severity text (also known as log level). The original string representation as
+    // it is known at the source. [Optional].
     severity_text: ManagedString = .Empty,
+    // A value containing the body of the log record. Can be for example a human-readable
+    // string message (including multi-line) describing the event in a free form or it can
+    // be a structured data composed of arrays and maps of other values. [Optional].
     body: ?opentelemetry_proto_common_v1.AnyValue = null,
+    // Additional attributes that describe the specific event occurrence. [Optional].
+    // Attribute keys MUST be unique (it is not allowed to have more than one
+    // attribute with the same key).
     attributes: ArrayList(opentelemetry_proto_common_v1.KeyValue),
     dropped_attributes_count: u32 = 0,
+    // Flags, a bit field. 8 least significant bits are the trace flags as
+    // defined in W3C Trace Context specification. 24 most significant bits are reserved
+    // and must be set to 0. Readers must not assume that 24 most significant bits
+    // will be zero and must correctly mask the bits when reading 8-bit trace flag (use
+    // flags & LOG_RECORD_FLAGS_TRACE_FLAGS_MASK). [Optional].
     flags: u32 = 0,
+    // A unique identifier for a trace. All logs from the same trace share
+    // the same `trace_id`. The ID is a 16-byte array. An ID with all zeroes OR
+    // of length other than 16 bytes is considered invalid (empty string in OTLP/JSON
+    // is zero-length and thus is also invalid).
+    //
+    // This field is optional.
+    //
+    // The receivers SHOULD assume that the log record is not associated with a
+    // trace if any of the following is true:
+    //   - the field is not present,
+    //   - the field contains an invalid value.
     trace_id: ManagedString = .Empty,
+    // A unique identifier for a span within a trace, assigned when the span
+    // is created. The ID is an 8-byte array. An ID with all zeroes OR of length
+    // other than 8 bytes is considered invalid (empty string in OTLP/JSON
+    // is zero-length and thus is also invalid).
+    //
+    // This field is optional. If the sender specifies a valid span_id then it SHOULD also
+    // specify a valid trace_id.
+    //
+    // The receivers SHOULD assume that the log record is not associated with a
+    // span if any of the following is true:
+    //   - the field is not present,
+    //   - the field contains an invalid value.
     span_id: ManagedString = .Empty,
 
     pub const _desc_table = .{

--- a/tests/generated/opentelemetry/proto/metrics/v1.pb.zig
+++ b/tests/generated/opentelemetry/proto/metrics/v1.pb.zig
@@ -131,6 +131,11 @@ pub const DataPointFlags = enum(i32) {
 // When new fields are added into this message, the OTLP request MUST be updated
 // as well.
 pub const MetricsData = struct {
+    // An array of ResourceMetrics.
+    // For data coming from a single resource this array will typically contain
+    // one element. Intermediary nodes that receive data from multiple origins
+    // typically batch the data before forwarding further and in that case this
+    // array will contain multiple elements.
     resource_metrics: ArrayList(ResourceMetrics),
 
     pub const _desc_table = .{
@@ -186,8 +191,16 @@ pub const MetricsData = struct {
 
 // A collection of ScopeMetrics from a Resource.
 pub const ResourceMetrics = struct {
+    // The resource for the metrics in this message.
+    // If this field is not set then no resource info is known.
     resource: ?opentelemetry_proto_resource_v1.Resource = null,
+    // A list of metrics that originate from a resource.
     scope_metrics: ArrayList(ScopeMetrics),
+    // The Schema URL, if known. This is the identifier of the Schema that the resource data
+    // is recorded in. To learn more about Schema URL see
+    // https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
+    // This schema_url applies to the data in the "resource" field. It does not apply
+    // to the data in the "scope_metrics" field which have their own schema_url field.
     schema_url: ManagedString = .Empty,
 
     pub const _desc_table = .{
@@ -245,8 +258,16 @@ pub const ResourceMetrics = struct {
 
 // A collection of Metrics produced by an Scope.
 pub const ScopeMetrics = struct {
+    // The instrumentation scope information for the metrics in this message.
+    // Semantically when InstrumentationScope isn't set, it is equivalent with
+    // an empty instrumentation scope name (unknown).
     scope: ?opentelemetry_proto_common_v1.InstrumentationScope = null,
+    // A list of metrics that originate from an instrumentation library.
     metrics: ArrayList(Metric),
+    // The Schema URL, if known. This is the identifier of the Schema that the metric data
+    // is recorded in. To learn more about Schema URL see
+    // https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
+    // This schema_url applies to all metrics in the "metrics" field.
     schema_url: ManagedString = .Empty,
 
     pub const _desc_table = .{
@@ -387,10 +408,24 @@ pub const ScopeMetrics = struct {
 // when the start time is truly unknown, setting StartTimeUnixNano is
 // strongly encouraged.
 pub const Metric = struct {
+    // name of the metric.
     name: ManagedString = .Empty,
+    // description of the metric, which can be used in documentation.
     description: ManagedString = .Empty,
+    // unit in which the metric value is reported. Follows the format
+    // described by http://unitsofmeasure.org/ucum.html.
     unit: ManagedString = .Empty,
+    // Additional metadata attributes that describe the metric. [Optional].
+    // Attributes are non-identifying.
+    // Consumers SHOULD NOT need to be aware of these attributes.
+    // These attributes MAY be used to encode information allowing
+    // for lossless roundtrip translation to / from another data model.
+    // Attribute keys MUST be unique (it is not allowed to have more than one
+    // attribute with the same key).
     metadata: ArrayList(opentelemetry_proto_common_v1.KeyValue),
+    // Data determines the aggregation type (if any) of the metric, what is the
+    // reported value type for the data points, as well as the relatationship to
+    // the time interval over which they are reported.
     data: ?data_union,
 
     pub const _data_case = enum {
@@ -537,7 +572,10 @@ pub const Gauge = struct {
 // reported measurements over a time interval.
 pub const Sum = struct {
     data_points: ArrayList(NumberDataPoint),
+    // aggregation_temporality describes if the aggregator reports delta changes
+    // since last report time, or cumulative changes since a fixed start time.
     aggregation_temporality: AggregationTemporality = @enumFromInt(0),
+    // If "true" means that the sum is monotonic.
     is_monotonic: bool = false,
 
     pub const _desc_table = .{
@@ -597,6 +635,8 @@ pub const Sum = struct {
 // as a Histogram of all reported measurements over a time interval.
 pub const Histogram = struct {
     data_points: ArrayList(HistogramDataPoint),
+    // aggregation_temporality describes if the aggregator reports delta changes
+    // since last report time, or cumulative changes since a fixed start time.
     aggregation_temporality: AggregationTemporality = @enumFromInt(0),
 
     pub const _desc_table = .{
@@ -655,6 +695,8 @@ pub const Histogram = struct {
 // as a ExponentialHistogram of all reported double measurements over a time interval.
 pub const ExponentialHistogram = struct {
     data_points: ArrayList(ExponentialHistogramDataPoint),
+    // aggregation_temporality describes if the aggregator reports delta changes
+    // since last report time, or cumulative changes since a fixed start time.
     aggregation_temporality: AggregationTemporality = @enumFromInt(0),
 
     pub const _desc_table = .{
@@ -772,11 +814,30 @@ pub const Summary = struct {
 // NumberDataPoint is a single data point in a timeseries that describes the
 // time-varying scalar value of a metric.
 pub const NumberDataPoint = struct {
+    // The set of key/value pairs that uniquely identify the timeseries from
+    // where this point belongs. The list may be empty (may contain 0 elements).
+    // Attribute keys MUST be unique (it is not allowed to have more than one
+    // attribute with the same key).
     attributes: ArrayList(opentelemetry_proto_common_v1.KeyValue),
+    // StartTimeUnixNano is optional but strongly encouraged, see the
+    // the detailed comments above Metric.
+    //
+    // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+    // 1970.
     start_time_unix_nano: u64 = 0,
+    // TimeUnixNano is required, see the detailed comments above Metric.
+    //
+    // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+    // 1970.
     time_unix_nano: u64 = 0,
+    // (Optional) List of exemplars collected from
+    // measurements that were used to form the data point
     exemplars: ArrayList(Exemplar),
+    // Flags that apply to this specific data point.  See DataPointFlags
+    // for the available flags and their meaning.
     flags: u32 = 0,
+    // The value itself.  A point is considered invalid when one of the recognized
+    // value fields is not present inside this oneof.
     value: ?value_union,
 
     pub const _value_case = enum {
@@ -859,16 +920,66 @@ pub const NumberDataPoint = struct {
 // "explicit_bounds" and "bucket_counts" must be omitted and only "count" and
 // "sum" are known.
 pub const HistogramDataPoint = struct {
+    // The set of key/value pairs that uniquely identify the timeseries from
+    // where this point belongs. The list may be empty (may contain 0 elements).
+    // Attribute keys MUST be unique (it is not allowed to have more than one
+    // attribute with the same key).
     attributes: ArrayList(opentelemetry_proto_common_v1.KeyValue),
+    // StartTimeUnixNano is optional but strongly encouraged, see the
+    // the detailed comments above Metric.
+    //
+    // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+    // 1970.
     start_time_unix_nano: u64 = 0,
+    // TimeUnixNano is required, see the detailed comments above Metric.
+    //
+    // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+    // 1970.
     time_unix_nano: u64 = 0,
+    // count is the number of values in the population. Must be non-negative. This
+    // value must be equal to the sum of the "count" fields in buckets if a
+    // histogram is provided.
     count: u64 = 0,
+    // sum of the values in the population. If count is zero then this field
+    // must be zero.
+    //
+    // Note: Sum should only be filled out when measuring non-negative discrete
+    // events, and is assumed to be monotonic over the values of these events.
+    // Negative events *can* be recorded, but sum should not be filled out when
+    // doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
+    // see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#histogram
     sum: ?f64 = null,
+    // bucket_counts is an optional field contains the count values of histogram
+    // for each bucket.
+    //
+    // The sum of the bucket_counts must equal the value in the count field.
+    //
+    // The number of elements in bucket_counts array must be by one greater than
+    // the number of elements in explicit_bounds array.
     bucket_counts: ArrayList(u64),
+    // explicit_bounds specifies buckets with explicitly defined bounds for values.
+    //
+    // The boundaries for bucket at index i are:
+    //
+    // (-infinity, explicit_bounds[i]] for i == 0
+    // (explicit_bounds[i-1], explicit_bounds[i]] for 0 < i < size(explicit_bounds)
+    // (explicit_bounds[i-1], +infinity) for i == size(explicit_bounds)
+    //
+    // The values in the explicit_bounds array must be strictly increasing.
+    //
+    // Histogram buckets are inclusive of their upper boundary, except the last
+    // bucket where the boundary is at infinity. This format is intentionally
+    // compatible with the OpenMetrics histogram definition.
     explicit_bounds: ArrayList(f64),
+    // (Optional) List of exemplars collected from
+    // measurements that were used to form the data point
     exemplars: ArrayList(Exemplar),
+    // Flags that apply to this specific data point.  See DataPointFlags
+    // for the available flags and their meaning.
     flags: u32 = 0,
+    // min is the minimum value over (start_time, end_time].
     min: ?f64 = null,
+    // max is the maximum value over (start_time, end_time].
     max: ?f64 = null,
 
     pub const _desc_table = .{
@@ -937,19 +1048,80 @@ pub const HistogramDataPoint = struct {
 // summary statistics for a population of values, it may optionally contain the
 // distribution of those values across a set of buckets.
 pub const ExponentialHistogramDataPoint = struct {
+    // The set of key/value pairs that uniquely identify the timeseries from
+    // where this point belongs. The list may be empty (may contain 0 elements).
+    // Attribute keys MUST be unique (it is not allowed to have more than one
+    // attribute with the same key).
     attributes: ArrayList(opentelemetry_proto_common_v1.KeyValue),
+    // StartTimeUnixNano is optional but strongly encouraged, see the
+    // the detailed comments above Metric.
+    //
+    // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+    // 1970.
     start_time_unix_nano: u64 = 0,
+    // TimeUnixNano is required, see the detailed comments above Metric.
+    //
+    // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+    // 1970.
     time_unix_nano: u64 = 0,
+    // count is the number of values in the population. Must be
+    // non-negative. This value must be equal to the sum of the "bucket_counts"
+    // values in the positive and negative Buckets plus the "zero_count" field.
     count: u64 = 0,
+    // sum of the values in the population. If count is zero then this field
+    // must be zero.
+    //
+    // Note: Sum should only be filled out when measuring non-negative discrete
+    // events, and is assumed to be monotonic over the values of these events.
+    // Negative events *can* be recorded, but sum should not be filled out when
+    // doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
+    // see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#histogram
     sum: ?f64 = null,
+    // scale describes the resolution of the histogram.  Boundaries are
+    // located at powers of the base, where:
+    //
+    //   base = (2^(2^-scale))
+    //
+    // The histogram bucket identified by `index`, a signed integer,
+    // contains values that are greater than (base^index) and
+    // less than or equal to (base^(index+1)).
+    //
+    // The positive and negative ranges of the histogram are expressed
+    // separately.  Negative values are mapped by their absolute value
+    // into the negative range using the same scale as the positive range.
+    //
+    // scale is not restricted by the protocol, as the permissible
+    // values depend on the range of the data.
     scale: i32 = 0,
+    // zero_count is the count of values that are either exactly zero or
+    // within the region considered zero by the instrumentation at the
+    // tolerated degree of precision.  This bucket stores values that
+    // cannot be expressed using the standard exponential formula as
+    // well as values that have been rounded to zero.
+    //
+    // Implementations MAY consider the zero bucket to have probability
+    // mass equal to (zero_count / count).
     zero_count: u64 = 0,
+    // positive carries the positive range of exponential bucket counts.
     positive: ?ExponentialHistogramDataPoint.Buckets = null,
+    // negative carries the negative range of exponential bucket counts.
     negative: ?ExponentialHistogramDataPoint.Buckets = null,
+    // Flags that apply to this specific data point.  See DataPointFlags
+    // for the available flags and their meaning.
     flags: u32 = 0,
+    // (Optional) List of exemplars collected from
+    // measurements that were used to form the data point
     exemplars: ArrayList(Exemplar),
+    // min is the minimum value over (start_time, end_time].
     min: ?f64 = null,
+    // max is the maximum value over (start_time, end_time].
     max: ?f64 = null,
+    // ZeroThreshold may be optionally set to convey the width of the zero
+    // region. Where the zero region is defined as the closed interval
+    // [-ZeroThreshold, ZeroThreshold].
+    // When ZeroThreshold is 0, zero count bucket stores values that cannot be
+    // expressed using the standard exponential formula as well as values that
+    // have been rounded to zero.
     zero_threshold: f64 = 0,
 
     pub const _desc_table = .{
@@ -972,7 +1144,19 @@ pub const ExponentialHistogramDataPoint = struct {
     // Buckets are a set of bucket counts, encoded in a contiguous array
     // of counts.
     pub const Buckets = struct {
+        // Offset is the bucket index of the first entry in the bucket_counts array.
+        //
+        // Note: This uses a varint encoding as a simple form of compression.
         offset: i32 = 0,
+        // bucket_counts is an array of count values, where bucket_counts[i] carries
+        // the count of the bucket at index (offset+i). bucket_counts[i] is the count
+        // of values greater than base^(offset+i) and less than or equal to
+        // base^(offset+i+1).
+        //
+        // Note: By contrast, the explicit HistogramDataPoint uses
+        // fixed64.  This field is expected to have many buckets,
+        // especially zeros, so uint64 has been selected to ensure
+        // varint encoding.
         bucket_counts: ArrayList(u64),
 
         pub const _desc_table = .{
@@ -1077,12 +1261,38 @@ pub const ExponentialHistogramDataPoint = struct {
 // SummaryDataPoint is a single data point in a timeseries that describes the
 // time-varying values of a Summary metric.
 pub const SummaryDataPoint = struct {
+    // The set of key/value pairs that uniquely identify the timeseries from
+    // where this point belongs. The list may be empty (may contain 0 elements).
+    // Attribute keys MUST be unique (it is not allowed to have more than one
+    // attribute with the same key).
     attributes: ArrayList(opentelemetry_proto_common_v1.KeyValue),
+    // StartTimeUnixNano is optional but strongly encouraged, see the
+    // the detailed comments above Metric.
+    //
+    // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+    // 1970.
     start_time_unix_nano: u64 = 0,
+    // TimeUnixNano is required, see the detailed comments above Metric.
+    //
+    // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+    // 1970.
     time_unix_nano: u64 = 0,
+    // count is the number of values in the population. Must be non-negative.
     count: u64 = 0,
+    // sum of the values in the population. If count is zero then this field
+    // must be zero.
+    //
+    // Note: Sum should only be filled out when measuring non-negative discrete
+    // events, and is assumed to be monotonic over the values of these events.
+    // Negative events *can* be recorded, but sum should not be filled out when
+    // doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
+    // see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#summary
     sum: f64 = 0,
+    // (Optional) list of values at different quantiles of the distribution calculated
+    // from the current snapshot. The quantiles must be strictly increasing.
     quantile_values: ArrayList(SummaryDataPoint.ValueAtQuantile),
+    // Flags that apply to this specific data point.  See DataPointFlags
+    // for the available flags and their meaning.
     flags: u32 = 0,
 
     pub const _desc_table = .{
@@ -1104,7 +1314,12 @@ pub const SummaryDataPoint = struct {
     // See the following issue for more context:
     // https://github.com/open-telemetry/opentelemetry-proto/issues/125
     pub const ValueAtQuantile = struct {
+        // The quantile of a distribution. Must be in the interval
+        // [0.0, 1.0].
         quantile: f64 = 0,
+        // The value at the given quantile of a distribution.
+        //
+        // Quantile values must NOT be negative.
         value: f64 = 0,
 
         pub const _desc_table = .{
@@ -1211,10 +1426,26 @@ pub const SummaryDataPoint = struct {
 // was recorded, for example the span and trace ID of the active span when the
 // exemplar was recorded.
 pub const Exemplar = struct {
+    // The set of key/value pairs that were filtered out by the aggregator, but
+    // recorded alongside the original measurement. Only key/value pairs that were
+    // filtered out by the aggregator should be included
     filtered_attributes: ArrayList(opentelemetry_proto_common_v1.KeyValue),
+    // time_unix_nano is the exact time when this exemplar was recorded
+    //
+    // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+    // 1970.
     time_unix_nano: u64 = 0,
+    // (Optional) Span ID of the exemplar trace.
+    // span_id may be missing if the measurement is not recorded inside a trace
+    // or if the trace is not sampled.
     span_id: ManagedString = .Empty,
+    // (Optional) Trace ID of the exemplar trace.
+    // trace_id may be missing if the measurement is not recorded inside a trace
+    // or if the trace is not sampled.
     trace_id: ManagedString = .Empty,
+    // The value of the measurement that was recorded. An exemplar is
+    // considered invalid when one of the recognized value fields is not present
+    // inside this oneof.
     value: ?value_union,
 
     pub const _value_case = enum {

--- a/tests/generated/opentelemetry/proto/resource/v1.pb.zig
+++ b/tests/generated/opentelemetry/proto/resource/v1.pb.zig
@@ -13,6 +13,7 @@ const UnionDecodingError = protobuf.UnionDecodingError;
 /// import package opentelemetry.proto.common.v1
 const opentelemetry_proto_common_v1 = @import("../common/v1.pb.zig");
 
+// Resource information.
 pub const Resource = struct {
     attributes: ArrayList(opentelemetry_proto_common_v1.KeyValue),
     dropped_attributes_count: u32 = 0,

--- a/tests/generated/opentelemetry/proto/resource/v1.pb.zig
+++ b/tests/generated/opentelemetry/proto/resource/v1.pb.zig
@@ -15,7 +15,12 @@ const opentelemetry_proto_common_v1 = @import("../common/v1.pb.zig");
 
 // Resource information.
 pub const Resource = struct {
+    // Set of attributes that describe the resource.
+    // Attribute keys MUST be unique (it is not allowed to have more than one
+    // attribute with the same key).
     attributes: ArrayList(opentelemetry_proto_common_v1.KeyValue),
+    // dropped_attributes_count is the number of dropped attributes. If the value is 0, then
+    // no attributes were dropped.
     dropped_attributes_count: u32 = 0,
 
     pub const _desc_table = .{

--- a/tests/generated/protobuf_test_messages/proto3.pb.zig
+++ b/tests/generated/protobuf_test_messages/proto3.pb.zig
@@ -20,6 +20,13 @@ pub const ForeignEnum = enum(i32) {
     _,
 };
 
+// This proto includes every type of field in both singular and repeated
+// forms.
+//
+// Also, crucially, all messages and enums in this file are eventually
+// submessages of this message.  So for example, a fuzz test of TestAllTypes
+// could trigger bugs that occur in any message type in this file.  We verify
+// this stays true in a unit test.
 pub const TestAllTypesProto3 = struct {
     optional_int32: i32 = 0,
     optional_int64: i64 = 0,
@@ -355,6 +362,7 @@ pub const TestAllTypesProto3 = struct {
     pub const AliasedEnum = enum(i32) {
         ALIAS_FOO = 0,
         ALIAS_BAR = 1,
+        // ALIAS_BAZ = 2;
         MOO = 2,
         _,
     };

--- a/tests/generated/protobuf_test_messages/proto3.pb.zig
+++ b/tests/generated/protobuf_test_messages/proto3.pb.zig
@@ -28,6 +28,7 @@ pub const ForeignEnum = enum(i32) {
 // could trigger bugs that occur in any message type in this file.  We verify
 // this stays true in a unit test.
 pub const TestAllTypesProto3 = struct {
+    // Singular
     optional_int32: i32 = 0,
     optional_int64: i64 = 0,
     optional_uint32: u32 = 0,
@@ -50,6 +51,7 @@ pub const TestAllTypesProto3 = struct {
     optional_aliased_enum: TestAllTypesProto3.AliasedEnum = @enumFromInt(0),
     optional_string_piece: ManagedString = .Empty,
     optional_cord: ManagedString = .Empty,
+    // Repeated
     repeated_int32: ArrayList(i32),
     repeated_int64: ArrayList(i64),
     repeated_uint32: ArrayList(u32),
@@ -71,6 +73,7 @@ pub const TestAllTypesProto3 = struct {
     repeated_foreign_enum: ArrayList(ForeignEnum),
     repeated_string_piece: ArrayList(ManagedString),
     repeated_cord: ArrayList(ManagedString),
+    // Packed
     packed_int32: ArrayList(i32),
     packed_int64: ArrayList(i64),
     packed_uint32: ArrayList(u32),
@@ -85,6 +88,7 @@ pub const TestAllTypesProto3 = struct {
     packed_double: ArrayList(f64),
     packed_bool: ArrayList(bool),
     packed_nested_enum: ArrayList(TestAllTypesProto3.NestedEnum),
+    // Unpacked
     unpacked_int32: ArrayList(i32),
     unpacked_int64: ArrayList(i64),
     unpacked_uint32: ArrayList(u32),
@@ -99,6 +103,7 @@ pub const TestAllTypesProto3 = struct {
     unpacked_double: ArrayList(f64),
     unpacked_bool: ArrayList(bool),
     unpacked_nested_enum: ArrayList(TestAllTypesProto3.NestedEnum),
+    // Map
     map_int32_int32: ArrayList(TestAllTypesProto3.MapInt32Int32Entry),
     map_int64_int64: ArrayList(TestAllTypesProto3.MapInt64Int64Entry),
     map_uint32_uint32: ArrayList(TestAllTypesProto3.MapUint32Uint32Entry),
@@ -118,6 +123,7 @@ pub const TestAllTypesProto3 = struct {
     map_string_foreign_message: ArrayList(TestAllTypesProto3.MapStringForeignMessageEntry),
     map_string_nested_enum: ArrayList(TestAllTypesProto3.MapStringNestedEnumEntry),
     map_string_foreign_enum: ArrayList(TestAllTypesProto3.MapStringForeignEnumEntry),
+    // Well-known types
     optional_bool_wrapper: ?google_protobuf.BoolValue = null,
     optional_int32_wrapper: ?google_protobuf.Int32Value = null,
     optional_int64_wrapper: ?google_protobuf.Int64Value = null,
@@ -150,6 +156,8 @@ pub const TestAllTypesProto3 = struct {
     repeated_any: ArrayList(google_protobuf.Any),
     repeated_value: ArrayList(google_protobuf.Value),
     repeated_list_value: ArrayList(google_protobuf.ListValue),
+    // Test field-name-to-JSON-name convention.
+    // (protobuf says names can be any valid C/C++ identifier.)
     fieldname1: i32 = 0,
     field_name2: i32 = 0,
     _field_name3: i32 = 0,

--- a/tests/generated/tests.pb.zig
+++ b/tests/generated/tests.pb.zig
@@ -166,6 +166,7 @@ pub const WithEnum = struct {
     }
 };
 
+// tests shadowing names
 pub const WithEnumShadow = struct {
     value: WithEnumShadow.SomeEnum = @enumFromInt(0),
 

--- a/tests/generated/unittest.pb.zig
+++ b/tests/generated/unittest.pb.zig
@@ -23,6 +23,7 @@ pub const TestReservedEnumFields = enum(i32) {
     _,
 };
 
+// Test an enum that has multiple values with the same number.
 pub const TestEnumWithDupValue = enum(i32) {
     FOO1 = 1,
     BAR1 = 2,
@@ -32,6 +33,7 @@ pub const TestEnumWithDupValue = enum(i32) {
     _,
 };
 
+// Test an enum with large, unordered values.
 pub const TestSparseEnum = enum(i32) {
     SPARSE_A = 123,
     SPARSE_B = 62374,
@@ -148,6 +150,8 @@ pub const VeryLargeEnum = enum(i32) {
     _,
 };
 
+// This proto includes every type of field in both singular and repeated
+// forms.
 pub const TestAllTypes = struct {
     optional_int32: ?i32 = null,
     optional_int64: ?i64 = null,
@@ -413,6 +417,7 @@ pub const TestAllTypes = struct {
     }
 };
 
+// This proto includes a recursively nested message.
 pub const NestedTestAllTypes = struct {
     child: ?ManagedStruct(NestedTestAllTypes) = null,
     payload: ?TestAllTypes = null,
@@ -581,6 +586,8 @@ pub const TestDeprecatedMessage = struct {
     }
 };
 
+// Define these after TestAllTypes to make sure the compiler can handle
+// that.
 pub const ForeignMessage = struct {
     c: ?i32 = null,
     d: ?i32 = null,
@@ -951,6 +958,8 @@ pub const TestChildExtension = struct {
     }
 };
 
+// Emulates wireformat data of TestChildExtension with dynamic extension
+// (DynamicExtension).
 pub const TestChildExtensionData = struct {
     a: ?ManagedString = null,
     b: ?ManagedString = null,
@@ -1175,6 +1184,8 @@ pub const TestNestedChildExtension = struct {
     }
 };
 
+// Emulates wireformat data of TestNestedChildExtension with dynamic extension
+// (DynamicExtension).
 pub const TestNestedChildExtensionData = struct {
     a: ?i32 = null,
     child: ?TestChildExtensionData = null,
@@ -1231,6 +1242,11 @@ pub const TestNestedChildExtensionData = struct {
     }
 };
 
+// We have separate messages for testing required fields because it's
+// annoying to have to fill in required fields in TestProto in order to
+// do anything with it.  Note that we don't need to test every type of
+// required filed because the code output is basically identical to
+// optional fields for all types.
 pub const TestRequired = struct {
     a: i32,
     dummy2: ?i32 = null,
@@ -1527,6 +1543,7 @@ pub const TestNestedRequiredForeign = struct {
     }
 };
 
+// Test that we can use NestedMessage from outside TestAllTypes.
 pub const TestForeignNested = struct {
     foreign_nested: ?TestAllTypes.NestedMessage = null,
 
@@ -1581,6 +1598,7 @@ pub const TestForeignNested = struct {
     }
 };
 
+// TestEmptyMessage is used to test unknown field support.
 pub const TestEmptyMessage = struct {
     pub const _desc_table = .{};
 
@@ -1631,6 +1649,8 @@ pub const TestEmptyMessage = struct {
     }
 };
 
+// Like above, but declare all field numbers as potential extensions.  No
+// actual extensions should ever be defined for this type.
 pub const TestEmptyMessageWithExtensions = struct {
     pub const _desc_table = .{};
 
@@ -1681,6 +1701,7 @@ pub const TestEmptyMessageWithExtensions = struct {
     }
 };
 
+// Needed for a Python test.
 pub const TestPickleNestedMessage = struct {
     pub const _desc_table = .{};
 
@@ -1889,6 +1910,7 @@ pub const TestMultipleExtensionRanges = struct {
     }
 };
 
+// Test that really large tag numbers don't break anything.
 pub const TestReallyLargeTagNumber = struct {
     a: ?i32 = null,
     bb: ?i32 = null,
@@ -2001,6 +2023,7 @@ pub const TestRecursiveMessage = struct {
     }
 };
 
+// Test that mutual recursion works.
 pub const TestMutualRecursionA = struct {
     bb: ?TestMutualRecursionB = null,
     sub_message: ?TestMutualRecursionA.SubMessage = null,
@@ -2277,6 +2300,10 @@ pub const TestIsInitialized = struct {
     }
 };
 
+// Test that groups have disjoint field numbers from their siblings and
+// parents.  This is NOT possible in proto1; only google.protobuf.  When
+// attempting to compile with proto1, this will emit an error; so we only
+// include it in protobuf_unittest_proto.
 pub const TestDupFieldNumber = struct {
     a: ?i32 = null,
 
@@ -2331,6 +2358,7 @@ pub const TestDupFieldNumber = struct {
     }
 };
 
+// Additional messages for testing lazy fields.
 pub const TestEagerMessage = struct {
     sub_message: ?TestAllTypes = null,
 
@@ -2551,6 +2579,7 @@ pub const TestEagerMaybeLazy = struct {
     }
 };
 
+// Needed for a Python test.
 pub const TestNestedMessageHasBits = struct {
     optional_nested_message: ?TestNestedMessageHasBits.NestedMessage = null,
 
@@ -2661,6 +2690,8 @@ pub const TestNestedMessageHasBits = struct {
     }
 };
 
+// Test message with CamelCase field names.  This violates Protocol Buffer
+// standard style.
 pub const TestCamelCaseFieldNames = struct {
     PrimitiveField: ?i32 = null,
     StringField: ?ManagedString = null,
@@ -2737,6 +2768,8 @@ pub const TestCamelCaseFieldNames = struct {
     }
 };
 
+// We list fields out of order, to ensure that we're using field number and not
+// field index to determine serialization order.
 pub const TestFieldOrderings = struct {
     my_string: ?ManagedString = null,
     my_int: ?i64 = null,
@@ -3175,6 +3208,7 @@ pub const SparseEnumMessage = struct {
     }
 };
 
+// Test String and Bytes: string is for valid UTF-8 strings
 pub const OneString = struct {
     data: ?ManagedString = null,
 
@@ -3507,6 +3541,7 @@ pub const ManyOptionalString = struct {
     }
 };
 
+// Test int32, uint32, int64, uint64, and bool are all compatible
 pub const Int32Message = struct {
     data: ?i32 = null,
 
@@ -3777,6 +3812,7 @@ pub const BoolMessage = struct {
     }
 };
 
+// Test oneofs.
 pub const TestOneof = struct {
     foo: ?foo_union,
 
@@ -4316,6 +4352,8 @@ pub const TestPackedTypes = struct {
     }
 };
 
+// A message with the same fields as TestPackedTypes, but without packing. Used
+// to test packed <-> unpacked wire compatibility.
 pub const TestUnpackedTypes = struct {
     unpacked_int32: ArrayList(i32),
     unpacked_int64: ArrayList(i64),
@@ -4496,6 +4534,9 @@ pub const TestUnpackedExtensions = struct {
     }
 };
 
+// Used by ExtensionSetTest/DynamicExtensions.  The test actually builds
+// a set of extensions to TestAllExtensions dynamically, based on the fields
+// of this message type.
 pub const TestDynamicExtensions = struct {
     scalar_extension: ?u32 = null,
     enum_extension: ?ForeignEnum = null,
@@ -4687,6 +4728,8 @@ pub const TestRepeatedScalarDifferentTagSizes = struct {
     }
 };
 
+// Test that if an optional or required message/group field appears multiple
+// times in the input, they need to be merged.
 pub const TestParsingMerge = struct {
     required_all_types: ?TestAllTypes = null,
     optional_all_types: ?TestAllTypes = null,
@@ -4702,6 +4745,11 @@ pub const TestParsingMerge = struct {
         .repeated_group_all_types = fd(21, .{ .SubMessage = {} }),
     };
 
+    // RepeatedFieldsGenerator defines matching field types as TestParsingMerge,
+    // except that all fields are repeated. In the tests, we will serialize the
+    // RepeatedFieldsGenerator to bytes, and parse the bytes to TestParsingMerge.
+    // Repeated fields in RepeatedFieldsGenerator are expected to be merged into
+    // the corresponding required/optional fields in TestParsingMerge.
     pub const RepeatedFieldsGenerator = struct {
         field1: ArrayList(TestAllTypes),
         field2: ArrayList(TestAllTypes),
@@ -4815,6 +4863,8 @@ pub const TestParsingMerge = struct {
     }
 };
 
+// Test that the correct exception is thrown by parseFrom in a corner case
+// involving merging, extensions, and required fields.
 pub const TestMergeException = struct {
     all_extensions: ?TestAllExtensions = null,
 
@@ -4923,6 +4973,8 @@ pub const TestCommentInjectionMessage = struct {
     }
 };
 
+// Used to check that the c++ code generator re-orders messages to reduce
+// padding.
 pub const TestMessageSize = struct {
     m1: ?bool = null,
     m2: ?i64 = null,
@@ -4987,6 +5039,7 @@ pub const TestMessageSize = struct {
     }
 };
 
+// Test that RPC services work.
 pub const FooRequest = struct {
     pub const _desc_table = .{};
 
@@ -6468,6 +6521,8 @@ pub const TestVerifyBigFieldNumberUint32 = struct {
     }
 };
 
+// This message contains different kind of enums to exercise the different
+// parsers in table-driven.
 pub const EnumParseTester = struct {
     optional_seq_small_0_lowfield: ?EnumParseTester.SeqSmall0 = null,
     optional_seq_small_0_midfield: ?EnumParseTester.SeqSmall0 = null,

--- a/tests/protos_for_test/generated_in_ci.proto
+++ b/tests/protos_for_test/generated_in_ci.proto
@@ -33,7 +33,9 @@ message WithNegativeIntegers {
 }
 
 message DemoWithAllVarint {
+    // This is an example nested enum comment.
     enum DemoEnum {
+      // My nested enum field comment.
       SomeValue = 0;
       SomeOther = 1;
       AndAnother = 2;


### PR DESCRIPTION
Only converts source leading comments into the generated Zig files; trailing comments/leading-detached comments seemed to add too much noise & inconsistent spacing/placements. 

Notably for trailing comments, I haven't found a good way to differentiate between inline trailing comments and trailing comments on a separate line, hence the problems with problematic placements.

For leading-detached comments, I'm not sure how to differentiate the number of newlines separation from above/below declarations. This seems to lead to misleading/confusing detached comments, as detached comments that are closer to e.g. below declaration may be separated with more newlines from above in the source `.proto` file, but with no clear separations in the resulting `.zig` file.

Any ideas for these comment types would be much appreciated.