### PR TITLE
use build.zig.zon to download protoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,11 @@ debug
 .specstory/*
 test.data
 benchmark/generated/**/*
+
+# nix devenv
+devenv.nix
+devenv.yaml
+devenv.lock
+.envrc
+*.nix
+.devenv

--- a/bootstrapped-generator/google/protobuf/compiler.pb.zig
+++ b/bootstrapped-generator/google/protobuf/compiler.pb.zig
@@ -88,12 +88,14 @@ pub const CodeGeneratorRequest = struct {
     file_to_generate: std.ArrayListUnmanaged([]const u8) = .empty,
     parameter: ?[]const u8 = null,
     proto_file: std.ArrayListUnmanaged(google_protobuf.FileDescriptorProto) = .empty,
+    source_file_descriptors: std.ArrayListUnmanaged(google_protobuf.FileDescriptorProto) = .empty,
     compiler_version: ?Version = null,
 
     pub const _desc_table = .{
         .file_to_generate = fd(1, .{ .repeated = .{ .scalar = .string } }),
         .parameter = fd(2, .{ .scalar = .string }),
         .proto_file = fd(15, .{ .repeated = .submessage }),
+        .source_file_descriptors = fd(17, .{ .repeated = .submessage }),
         .compiler_version = fd(3, .submessage),
     };
 
@@ -164,17 +166,22 @@ pub const CodeGeneratorRequest = struct {
 pub const CodeGeneratorResponse = struct {
     @"error": ?[]const u8 = null,
     supported_features: ?u64 = null,
+    minimum_edition: ?i32 = null,
+    maximum_edition: ?i32 = null,
     file: std.ArrayListUnmanaged(CodeGeneratorResponse.File) = .empty,
 
     pub const _desc_table = .{
         .@"error" = fd(1, .{ .scalar = .string }),
         .supported_features = fd(2, .{ .scalar = .uint64 }),
+        .minimum_edition = fd(3, .{ .scalar = .int32 }),
+        .maximum_edition = fd(4, .{ .scalar = .int32 }),
         .file = fd(15, .{ .repeated = .submessage }),
     };
 
     pub const Feature = enum(i32) {
         FEATURE_NONE = 0,
         FEATURE_PROTO3_OPTIONAL = 1,
+        FEATURE_SUPPORTS_EDITIONS = 2,
         _,
     };
 

--- a/build.zig
+++ b/build.zig
@@ -155,15 +155,16 @@ pub fn build(b: *std.Build) !void {
         test_step.dependOn(&run_main_tests.step);
     }
 
-    const wd = try build_util.getProtocInstallDir(std.heap.page_allocator, PROTOC_VERSION);
+    const protoc = try build_util.getProtocDependency(b);
+    const include = protoc.path("include").getPath(b);
 
     const bootstrap = b.step("bootstrap", "run the generator over its own sources");
 
     const bootstrapConversion = RunProtocStep.create(b, b, target, .{
         .destination_directory = b.path("bootstrapped-generator"),
         .source_files = &.{
-            b.pathJoin(&.{ wd, "include/google/protobuf/compiler/plugin.proto" }),
-            b.pathJoin(&.{ wd, "include/google/protobuf/descriptor.proto" }),
+            b.pathJoin(&.{ include, "google/protobuf/compiler/plugin.proto" }),
+            b.pathJoin(&.{ include, "google/protobuf/descriptor.proto" }),
         },
         .include_directories = &.{},
     });

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,43 +1,49 @@
 .{
     .name = .protobuf,
-    // This is a [Semantic Version](https://semver.org/).
-    // In a future version of Zig it will be used for package deduplication.
-    .version = "2.0.0",
+    .version = "3.0.0",
 
     .fingerprint = 0x99fac5be6a36efd1,
 
-    // This field is optional.
-    // This is currently advisory only; Zig does not yet do anything
-    // with this value.
-    .minimum_zig_version = "0.14.0",
+    .minimum_zig_version = "0.15.1",
 
-    // This field is optional.
-    // Each dependency must either provide a `url` and `hash`, or a `path`.
-    // `zig build --fetch` can be used to fetch all dependencies of a package, recursively.
-    // Once all dependencies are fetched, `zig build` no longer requires
-    // internet connectivity.
-    //.dependencies = .{
-    //},
-
-    // Specifies the set of files and directories that are included in this package.
-    // Only files and directories listed here are included in the `hash` that
-    // is computed for this package.
-    // Paths are relative to the build root. Use the empty string (`""`) to refer to
-    // the build root itself.
-    // A directory listed here means that all files within, recursively, are included.
-    .dependencies = .{},
+    .dependencies = .{
+        .@"protoc-linux-64" = .{
+            .url = "https://github.com/protocolbuffers/protobuf/releases/download/v32.1/protoc-32.1-win64.zip",
+            .hash = "N-V-__8AAAOIwgCuuT3IhPlAW6erD8SspcE7iVKY4nbJWLV6",
+            .lazy = true,
+        },
+        .@"protoc-linux-x86_64" = .{
+            .url = "https://github.com/protocolbuffers/protobuf/releases/download/v32.1/protoc-32.1-linux-x86_64.zip",
+            .hash = "N-V-__8AAGKbngAmNuaBMSXq_WgmQi6N8WVWVKp0moFSTvoJ",
+            .lazy = true,
+        },
+        .@"protoc-linux-x86_32" = .{
+            .url = "https://github.com/protocolbuffers/protobuf/releases/download/v32.1/protoc-32.1-linux-x86_32.zip",
+            .hash = "N-V-__8AAHpvrAAEcEurDCWYQt6jTJSozCfLDwkGTptKEyJ7",
+            .lazy = true,
+        },
+        .@"protoc-linux-aarch_64" = .{
+            .url = "https://github.com/protocolbuffers/protobuf/releases/download/v32.1/protoc-32.1-linux-aarch_64.zip",
+            .hash = "N-V-__8AAJKMngA8y82sENkRg-JF100BtRa7GQxoBIfU3c3_",
+            .lazy = true,
+        },
+        .@"protoc-osx-aarch_64" = .{
+            .url = "https://github.com/protocolbuffers/protobuf/releases/download/v32.1/protoc-32.1-osx-aarch_64.zip",
+            .hash = "N-V-__8AANrukAA2AHP6xuzchs_iwsyg1UYhIFhpUR6R0x7K",
+            .lazy = true,
+        },
+        .@"protoc-osx-x86_64" = .{
+            .url = "https://github.com/protocolbuffers/protobuf/releases/download/v32.1/protoc-32.1-osx-x86_64.zip",
+            .hash = "N-V-__8AAFoXkgBrHnNjViSdp84aL1ciwtWKZdYHK7dSSppd",
+            .lazy = true,
+        },
+        .@"protoc-win64" = .{
+            .url = "https://github.com/protocolbuffers/protobuf/releases/download/v32.1/protoc-32.1-win64.zip",
+            .hash = "N-V-__8AAAOIwgCuuT3IhPlAW6erD8SspcE7iVKY4nbJWLV6",
+            .lazy = true,
+        },
+    },
     .paths = .{
-        // This makes *all* files, recursively, included in this package. It is generally
-        // better to explicitly list the files and directories instead, to insure that
-        // fetching from tarballs, file system paths, and version control all result
-        // in the same contents hash.
-        "",
-        // For example...
-        //"build.zig",
-        //"build.zig.zon",
-        //"src",
-        //"LICENSE",
-        //"README.md",
         "build.zig",
         "build.zig.zon",
         "utils/build_util.zig",

--- a/update-protoc.sh
+++ b/update-protoc.sh
@@ -1,0 +1,9 @@
+PROTOC_VERSION=32.1
+
+zig fetch --save=protoc-linux-x86_64 "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip"
+zig fetch --save=protoc-linux-x86_32 "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_32.zip"
+zig fetch --save=protoc-linux-s390 "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-s390_64.zip"
+zig fetch --save=protoc-linux-aarch_64 "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-aarch_64.zip"
+zig fetch --save=protoc-osx-aarch_64 "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-osx-aarch_64.zip"
+zig fetch --save=protoc-osx-x86_64 "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-osx-x86_64.zip"
+zig fetch --save=protoc-win64 "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-win64.zip"

--- a/utils/build_util.zig
+++ b/utils/build_util.zig
@@ -1,10 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
-// Shared state for thread safety
-pub var download_mutex = std.Thread.Mutex{};
-
-pub const PROTOC_VERSION = "23.4";
+pub const PROTOC_VERSION = "32.1";
 
 // File system utilities
 pub fn dirExists(path: []const u8) bool {
@@ -19,14 +16,6 @@ pub fn fileExists(path: []const u8) bool {
     return true;
 }
 
-pub fn sdkPath(comptime suffix: []const u8) []const u8 {
-    if (suffix[0] != '/') @compileError("suffix must be an absolute path");
-    return comptime blk: {
-        const root_dir = std.fs.path.dirname(@src().file) orelse ".";
-        break :blk root_dir ++ suffix;
-    };
-}
-
 // Environment utilities
 pub fn isEnvVarTruthy(allocator: std.mem.Allocator, name: []const u8) bool {
     if (std.process.getEnvVarOwned(allocator, name)) |truthy| {
@@ -38,139 +27,14 @@ pub fn isEnvVarTruthy(allocator: std.mem.Allocator, name: []const u8) bool {
     }
 }
 
-pub fn getGitHubBaseURLOwned(allocator: std.mem.Allocator) ![]const u8 {
-    if (std.process.getEnvVarOwned(allocator, "GITHUB_BASE_URL")) |base_url| {
-        std.log.info("zig-protobuf: respecting GITHUB_BASE_URL: {s}\n", .{base_url});
-        return base_url;
-    } else |_| {
-        return allocator.dupe(u8, "https://github.com");
-    }
-}
-
-// Download utilities
-pub fn downloadFile(allocator: std.mem.Allocator, target_file: []const u8, url: []const u8) !void {
-    std.debug.print("downloading {s}..\n", .{url});
-
-    var child = if (isEnvVarTruthy(allocator, "CURL_INSECURE"))
-        std.process.Child.init(&.{ "curl", "--insecure", "-L", "-o", target_file, url }, allocator)
-    else
-        std.process.Child.init(&.{ "curl", "-L", "-o", target_file, url }, allocator);
-    child.cwd = sdkPath("/");
-    child.stderr = std.fs.File.stderr();
-    child.stdout = std.fs.File.stdout();
-    _ = try child.spawnAndWait();
-}
-
-pub fn unzipFile(allocator: std.mem.Allocator, file: []const u8, target_directory: []const u8) !void {
-    var child = switch (builtin.os.tag) {
-        .windows => std.process.Child.init(
-            &.{ "powershell", "-Command", "Expand-Archive -Force -Path", file, "-DestinationPath", target_directory },
-            allocator,
-        ),
-        else => std.process.Child.init(
-            &.{ "unzip", "-o", file, "-d", target_directory },
-            allocator,
-        ),
-    };
-    child.cwd = sdkPath("/");
-    child.stderr = std.fs.File.stderr();
-    child.stdout = std.fs.File.stdout();
-    _ = try child.spawnAndWait();
-}
-
-pub fn ensureCanDownloadFiles(allocator: std.mem.Allocator) void {
-    const result = std.process.Child.run(.{
-        .allocator = allocator,
-        .argv = &.{ "curl", "--version" },
-        .cwd = sdkPath("/"),
-    }) catch {
-        std.log.err("zig-protobuf: error: 'curl --version' failed. Is curl not installed?", .{});
-        std.process.exit(1);
-    };
-    defer {
-        allocator.free(result.stderr);
-        allocator.free(result.stdout);
-    }
-    if (result.term.Exited != 0) {
-        std.log.err("zig-protobuf: error: 'curl --version' failed. Is curl not installed?", .{});
-        std.process.exit(1);
-    }
-}
-
-pub fn ensureCanUnzipFiles(allocator: std.mem.Allocator) void {
-    switch (builtin.os.tag) {
-        .windows => {},
-        else => {
-            const result = std.process.Child.run(.{
-                .allocator = allocator,
-                .argv = &.{"unzip"},
-                .cwd = sdkPath("/"),
-            }) catch {
-                std.log.err("zig-protobuf: error: 'unzip' failed. Is unzip not installed?", .{});
-                std.process.exit(1);
-            };
-            defer {
-                allocator.free(result.stderr);
-                allocator.free(result.stdout);
-            }
-            if (result.term.Exited != 0) {
-                std.log.err("zig-protobuf: error: 'unzip' failed. Is unzip not installed?", .{});
-                std.process.exit(1);
-            }
-        },
-    }
-}
-
-// Protoc utilities
-pub fn getProtocInstallDir(
-    allocator: std.mem.Allocator,
-    protoc_version: []const u8,
-) ![]const u8 {
-    if (std.process.getEnvVarOwned(allocator, "PROTOC_PATH") catch null) |protoc_path| {
-        std.log.info("zig-protobuf: respecting PROTOC_PATH: {s}\n", .{protoc_path});
-        if (fileExists(protoc_path)) {
-            const bin_dir = std.fs.path.dirname(protoc_path).?;
-            const real_proto_dir = std.fs.path.dirname(bin_dir).?;
-            return real_proto_dir;
-        }
-
-        std.log.err("zig-protobuf: cannot resolve a protoc provided via PROTOC_PATH env var ({s}), make sure the value is correct", .{protoc_path});
-        std.process.exit(1);
-    }
-
-    const base_cache_dir_rel = try std.fs.path.join(allocator, &.{ ".zig-cache", "zig-protobuf", "protoc" });
-    try std.fs.cwd().makePath(base_cache_dir_rel);
-    const base_cache_dir = try std.fs.cwd().realpathAlloc(allocator, base_cache_dir_rel);
-    const versioned_cache_dir = try std.fs.path.join(allocator, &.{ base_cache_dir, protoc_version });
-    defer {
-        allocator.free(base_cache_dir_rel);
-        allocator.free(base_cache_dir);
-        allocator.free(versioned_cache_dir);
-    }
-
-    const target_cache_dir = try std.fs.path.join(allocator, &.{ versioned_cache_dir, @tagName(builtin.os.tag), @tagName(builtin.cpu.arch) });
-    return target_cache_dir;
-}
-
 pub fn ensureProtocBinaryDownloaded(
-    allocator: std.mem.Allocator,
-    protoc_version: []const u8,
+    b: *std.Build,
 ) ![]const u8 {
-    const target_cache_dir = try getProtocInstallDir(allocator, protoc_version);
-
-    const executable_path = if (builtin.os.tag == .windows)
-        try std.fs.path.join(allocator, &.{ target_cache_dir, "bin", "protoc.exe" })
-    else
-        try std.fs.path.join(allocator, &.{ target_cache_dir, "bin", "protoc" });
+    const executable_path = try getProtocBin(b);
 
     if (fileExists(executable_path)) {
         return executable_path;
     }
-
-    downloadProtoc(allocator, target_cache_dir, protoc_version) catch |err| {
-        std.log.err("zig-protobuf: download protoc failed: {s}", .{@errorName(err)});
-        std.process.exit(1);
-    };
 
     if (!fileExists(executable_path)) {
         std.log.err("zig-protobuf: file not found: {s}", .{executable_path});
@@ -180,10 +44,7 @@ pub fn ensureProtocBinaryDownloaded(
     return executable_path;
 }
 
-pub fn getProtocDownloadLink(allocator: std.mem.Allocator, version: []const u8) !?[]const u8 {
-    const github_base_url = try getGitHubBaseURLOwned(allocator);
-    defer allocator.free(github_base_url);
-
+pub fn getProtocDependency(b: *std.Build) !*std.Build.Dependency {
     const os: ?[]const u8 = switch (builtin.os.tag) {
         .macos => "osx",
         .linux => "linux",
@@ -199,55 +60,28 @@ pub fn getProtocDownloadLink(allocator: std.mem.Allocator, version: []const u8) 
         else => null,
     };
 
-    const asset = if (builtin.os.tag == .windows)
-        try std.mem.concat(allocator, u8, &.{ "protoc-", version, "-win64.zip" })
+    const dependencyName = if (builtin.os.tag == .windows)
+        try std.mem.concat(b.allocator, u8, &.{"protoc-win64.zip"})
     else if (os != null and arch != null)
-        try std.mem.concat(allocator, u8, &.{ "protoc-", version, "-", os.?, "-", arch.?, ".zip" })
+        try std.mem.concat(b.allocator, u8, &.{ "protoc-", os.?, "-", arch.? })
     else
-        return null;
-    defer allocator.free(asset);
+        @panic("Platform not supported");
+    defer b.allocator.free(dependencyName);
 
-    return try std.mem.concat(allocator, u8, &.{
-        github_base_url,
-        "/protocolbuffers/protobuf/releases/download/v",
-        version,
-        "/",
-        asset,
-    });
-}
-
-pub fn downloadProtoc(
-    allocator: std.mem.Allocator,
-    target_cache_dir: []const u8,
-    protoc_version: []const u8,
-) !void {
-    download_mutex.lock();
-    defer download_mutex.unlock();
-
-    ensureCanDownloadFiles(allocator);
-    ensureCanUnzipFiles(allocator);
-
-    const download_dir = try std.fs.path.join(allocator, &.{ target_cache_dir, "download" });
-    defer allocator.free(download_dir);
-    std.fs.cwd().makePath(download_dir) catch @panic(download_dir);
-    std.debug.print("download_dir: {s}\n", .{download_dir});
-
-    const download_url = try getProtocDownloadLink(allocator, protoc_version);
-
-    if (download_url == null) {
-        std.log.err("zig-protobuf: cannot resolve a protoc version to download. make sure the architecture you are using is supported", .{});
-        std.process.exit(1);
+    if (b.lazyDependency(dependencyName, .{})) |dep| {
+        return dep;
     }
 
-    defer allocator.free(download_url.?);
+    @panic("Platform not supported");
+}
 
-    const zip_target_file = try std.fs.path.join(allocator, &.{ download_dir, "protoc.zip" });
-    defer allocator.free(zip_target_file);
-    downloadFile(allocator, zip_target_file, download_url.?) catch @panic(zip_target_file);
-
-    unzipFile(allocator, zip_target_file, target_cache_dir) catch @panic(zip_target_file);
-
-    try std.fs.deleteTreeAbsolute(download_dir);
+pub fn getProtocBin(b: *std.Build) ![]const u8 {
+    const dep = try getProtocDependency(b);
+    
+    if (builtin.os.tag == .windows)
+        return dep.path("bin/protoc.exe").getPath(b);
+        
+    return dep.path("bin/protoc").getPath(b);
 }
 
 pub const RunProtocStep = struct {
@@ -331,7 +165,7 @@ pub const RunProtocStep = struct {
         { // run protoc
             var argv: std.ArrayList([]const u8) = .empty;
 
-            const protoc_path = try ensureProtocBinaryDownloaded(b.allocator, PROTOC_VERSION);
+            const protoc_path = try ensureProtocBinaryDownloaded(b);
             try argv.append(b.allocator, protoc_path);
 
             try argv.append(b.allocator, try std.mem.concat(


### PR DESCRIPTION
Remove dependencies on `curl` and `unzip` to leverage zig's lazyDependencies.

This approach also ensures that the downloaded protoc files are not altered via hash verifications.