### PR TITLE
fix(wire): exclude logging for freestanding targets

### DIFF
--- a/src/wire.zig
+++ b/src/wire.zig
@@ -2,7 +2,14 @@
 const std = @import("std");
 
 const protobuf = @import("protobuf.zig");
-const log = std.log.scoped(.zig_protobuf);
+const builtin = @import("builtin");
+const log = if (builtin.os.tag != .freestanding) std.log.scoped(.zig_protobuf) else struct {
+    // no-op log implementation for freestanding targets
+    pub fn debug(
+        comptime _: []const u8,
+        _: anytype,
+    ) void {}
+};
 
 /// Wire type.
 pub const Type = enum(u3) {


### PR DESCRIPTION
The std.log is unsupported for operating system freestanding. As there is just one instance in the library this change enables it to be used when targetting wasm-freestanding

The original error I was encountering

```
/home/.local/bin/zig/lib/std/Thread.zig:579:9: error: Unsupported operating system freestanding
        @compileError("Unsupported operating system " ++ @tagName(native_os));
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
referenced by:
    getCurrentId: /home/.local/bin/zig/lib/std/Thread.zig:554:27
    getCurrentId: /home/.local/bin/zig/lib/std/Thread.zig:375:29
    lock: /home/.local/bin/zig/lib/std/Thread/Mutex/Recursive.zig:50:54
    lockStderrWriter: /home/.local/bin/zig/lib/std/Progress.zig:652:22
    lockStderrWriter: /home/.local/bin/zig/lib/std/debug.zig:215:41
    defaultLog__anon_11731: /home/.local/bin/zig/lib/std/log.zig:154:46
    log__anon_11512: /home/.local/bin/zig/lib/std/log.zig:124:22
    debug__anon_11436: /home/.local/bin/zig/lib/std/log.zig:199:16
    skipField: /home/.cache/zig/p/protobuf-3.0.0-0e82anPRKADr_h_KCVG8ZMCa5fVi4KRpk_e6RH-SnG-k/src/wire.zig:1056:14
```