### PR TITLE
std.meta.intToEnum -> std.enums.fromInt

### DIFF
--- a/src/wire.zig
+++ b/src/wire.zig
@@ -529,7 +529,7 @@ pub fn decodeMessage(
         };
         consumed += tag_c;
 
-        @setEvalBranchQuota(40_000);
+        @setEvalBranchQuota(50_000);
         inline for (@typeInfo(@TypeOf(desc_table)).@"struct".fields) |field| {
             const field_desc: protobuf.FieldDescriptor =
                 comptime @field(desc_table, field.name);


### PR DESCRIPTION
`std.meta.intToEnum` was deprecated in 0.15 and is removed for 0.16

This patch fixes `zig build` but `zig build test` fails because of too much eval branches, suggestions welcome