### PR TITLE
fix(build): allow for relative build paths

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,7 +4,7 @@
 
     .fingerprint = 0x99fac5be6a36efd1,
 
-    .minimum_zig_version = "0.15.1",
+    .minimum_zig_version = "0.16.0-dev.2510+bcb5218a2",
 
     .dependencies = .{
         .@"protoc-linux-64" = .{


### PR DESCRIPTION
 - Set `minimum_zig_version` to allow ZLS to work automatically in VS Code
 - Flatten `dirExists` and `fileExists` into `pathExists`
 - Allow for relative build paths

The goal here is to support generating code into `.zig-cache/` and importing as an anonymous module. The following snippet works in my project after this change:

```zig
    // Obtain a handle to a generated directory in .zig-cache where we can write the output of `protoc`.
    const wf = b.addWriteFiles();

    const protoc = protobuf.RunProtocStep.create(protobuf_dep.builder, target, .{
        .destination_directory = wf.getDirectory(),
        .include_directories = &.{b.path("proto")},
        .source_files = &.{
            b.path("proto/One.proto"),
            b.path("proto/Two.proto"),
        },
    });

    // After `protoc` runs, there should be a single file named `PACKAGE.pb.zig` in the output directory.
    const root = try wf.getDirectory().join(b.allocator, "PACKAGE.pb.zig");

    // And make it available as an anonymous import to the root module,
    // so that it can be imported with `@import("PACKAGE.pb")` from any source file.
    mod.addAnonymousImport("PACKAGE.pb", .{
        .root_source_file = root,
        .target = target,
        .optimize = optimize,
    });

    protoc.step.dependOn(&wf.step);
    compile.step.dependOn(&protoc.step);
```