### PR TITLE
Update protobuf version from 3.0.0 to 4.0.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .protobuf,
-    .version = "3.0.0",
+    .version = "4.0.0",
 
     .fingerprint = 0x99fac5be6a36efd1,
 


### PR DESCRIPTION
My build.zig.zon hash was still showing 3.0.0

```
        .protobuf = .{
            .url = "https://github.com/Arwalk/zig-protobuf/archive/refs/tags/v4.0.0.tar.gz",
            .hash = "protobuf-3.0.0-0e82avQuKADcHgDzDixSMGN22hzGEgwFE0tEJUWnWu5Q",
        },
```