### PR TITLE
Include the package name in generated service struct

### DIFF
--- a/bootstrapped-generator/main.zig
+++ b/bootstrapped-generator/main.zig
@@ -990,6 +990,14 @@ const GenerationContext = struct {
                 allocator,
                 try std.fmt.allocPrint(
                     allocator,
+                    "        pub const package = \"{s}\";\n",
+                    .{fqn.buf},
+                ),
+            );
+            try lines.append(
+                allocator,
+                try std.fmt.allocPrint(
+                    allocator,
                     "        pub const service_name = \"{s}\";\n\n",
                     .{service_name},
                 ),

--- a/tests/generated/tests/service.pb.zig
+++ b/tests/generated/tests/service.pb.zig
@@ -281,6 +281,7 @@ pub const StreamResponse = struct {
 /// This service demonstrates basic request-response pattern
 pub fn SimpleService(comptime UserDataType: type, comptime ErrorSet: type) type {
     return struct {
+        pub const package = "tests.service";
         pub const service_name = "SimpleService";
 
         /// Performs a simple unary call
@@ -293,6 +294,7 @@ pub fn SimpleService(comptime UserDataType: type, comptime ErrorSet: type) type 
 /// Service demonstrating all streaming patterns
 pub fn StreamingService(comptime UserDataType: type, comptime ErrorSet: type) type {
     return struct {
+        pub const package = "tests.service";
         pub const service_name = "StreamingService";
 
         /// Server streaming RPC - client sends one request, server sends stream of responses

--- a/tests/generated/unittest.pb.zig
+++ b/tests/generated/unittest.pb.zig
@@ -7944,6 +7944,7 @@ pub const EnumParseTester = struct {
 
 pub fn TestService(comptime UserDataType: type, comptime ErrorSet: type) type {
     return struct {
+        pub const package = "unittest";
         pub const service_name = "TestService";
 
         Foo: *const fn (userdata: *UserDataType, request: FooRequest) ErrorSet!FooResponse,


### PR DESCRIPTION
Hi,

In order to generate the client-side stub from the generated VTable at comptime, we need the package name, to build the fully qualified name `/package.service/Method`.