### PR TITLE
Fix panic when shrinking to size larger than length

### DIFF
--- a/src/wire.zig
+++ b/src/wire.zig
@@ -382,11 +382,8 @@ pub fn decodeRepeated(
     ).pointer.child;
     comptime std.debug.assert(ResultList == std.ArrayList(Result));
 
-    const current_capacity = result.capacity;
-    errdefer result.shrinkAndFree(allocator, current_capacity);
-
     const current_items = result.items.len;
-    errdefer result.shrinkRetainingCapacity(current_items);
+    errdefer result.shrinkAndFree(allocator, current_items);
 
     switch (comptime field) {
         .scalar => |scalar| {
@@ -501,6 +498,31 @@ test decodeRepeated {
             &.{ 3, 270, 86942 },
             list.items,
         );
+    }
+    // Pre-allocated capacity (capacity=8, items=0) + malformed packed field:
+    // two 2-byte varints (4 bytes consumed) against options.bytes=3 triggers
+    // error.InvalidInput. The buggy errdefer then calls
+    // shrinkAndFree(allocator, current_capacity=8) with items.len==0, panicking.
+    {
+        var list: std.ArrayList(u32) = .empty;
+        defer list.deinit(std.testing.allocator);
+        try list.ensureTotalCapacity(std.testing.allocator, 8);
+
+        // Two varints encoding 270 (0x8e 0x02 each); consumed=4 but options.bytes=3.
+        const input: []const u8 = &.{ 0x8e, 0x02, 0x8e, 0x02 };
+        var reader: std.Io.Reader = .fixed(input);
+
+        try std.testing.expectError(
+            error.InvalidInput,
+            decodeRepeated(
+                &list,
+                std.testing.allocator,
+                .{ .scalar = .uint32 },
+                &reader,
+                .{ .bytes = 3 },
+            ),
+        );
+        try std.testing.expectEqual(0, list.items.len);
     }
 }
 

--- a/src/wire.zig
+++ b/src/wire.zig
@@ -383,7 +383,7 @@ pub fn decodeRepeated(
     comptime std.debug.assert(ResultList == std.ArrayList(Result));
 
     const current_items = result.items.len;
-    errdefer result.shrinkAndFree(allocator, current_items);
+    errdefer result.shrinkRetainingCapacity(current_items);
 
     switch (comptime field) {
         .scalar => |scalar| {


### PR DESCRIPTION
## Overview

In src/wire.zig, decodeRepeated had two errdefer cleanup handlers registered when entering the function:

  1. errdefer result.shrinkAndFree(allocator, current_capacity) — would free down to the pre-call capacity.
  2. errdefer result.shrinkRetainingCapacity(current_items) — would shrink items back to the pre-call item count.

  The panic occurred because shrinkAndFree asserts that the new size must be <= items.len. If the list had pre-allocated capacity
  (e.g., capacity=8) but zero items, and decoding failed before appending anything, current_capacity (8) would be greater than
  items.len (0), violating that invariant and causing a panic.
  
## Test

Added test that triggers the panic in current master branch.

## Logs of personal app that triggered the error.

<details>
<summary>Panic stack trace of app</summary>

```
thread 1540402 panic: reached unreachable code
/usr/local/zig/lib/std/debug.zig:420:14: 0x1051849 in assert (std.zig)
    if (!ok) unreachable; // assertion failure
             ^
/usr/local/zig/lib/std/array_list.zig:1134:19: 0x125b259 in shrinkAndFreePrecise (std.zig)
            assert(new_len <= self.items.len);
                  ^
/usr/local/zig/lib/std/array_list.zig:1120:38: 0x125afa1 in shrinkAndFree (std.zig)
            self.shrinkAndFreePrecise(gpa, new_len) catch |e| switch (e) {
                                     ^
/home/gulolio/Documents/Zig/Practice/grpc/zig-pkg/protobuf-5.0.0-0e82avKUKAAVwTWJzTIEZ14Fu0zC11_lElR8tE6H__y1/src/wire.zig:386:34: 0x1255fe4 in decodeRepeated__anon_43344 (protobuf.zig)
    errdefer result.shrinkAndFree(allocator, current_capacity);
                                 ^
/home/gulolio/Documents/Zig/Practice/grpc/zig-pkg/protobuf-5.0.0-0e82avKUKAAVwTWJzTIEZ14Fu0zC11_lElR8tE6H__y1/src/wire.zig:720:51: 0x1250eb9 in decodeMessage__anon_43120 (protobuf.zig)
                    consumed += try decodeRepeated(
                                                  ^
/home/gulolio/Documents/Zig/Practice/grpc/zig-pkg/protobuf-5.0.0-0e82avKUKAAVwTWJzTIEZ14Fu0zC11_lElR8tE6H__y1/src/wire.zig:797:71: 0x124d6ba in decodeMessage__anon_43015 (protobuf.zig)
                            const message_consumed = try decodeMessage(
                                                                      ^
/home/gulolio/Documents/Zig/Practice/grpc/zig-pkg/protobuf-5.0.0-0e82avKUKAAVwTWJzTIEZ14Fu0zC11_lElR8tE6H__y1/src/wire.zig:797:71: 0x1273ea9 in decodeMessage__anon_41661 (protobuf.zig)
                            const message_consumed = try decodeMessage(
                                                                      ^
/home/gulolio/Documents/Zig/Practice/grpc/zig-pkg/protobuf-5.0.0-0e82avKUKAAVwTWJzTIEZ14Fu0zC11_lElR8tE6H__y1/src/wire.zig:1027:77: 0x12281d6 in decodeMessage__anon_41457 (protobuf.zig)
                                        const m_consumed = try decodeMessage(
                                                                            ^
/home/gulolio/Documents/Zig/Practice/grpc/zig-pkg/protobuf-5.0.0-0e82avKUKAAVwTWJzTIEZ14Fu0zC11_lElR8tE6H__y1/src/protobuf.zig:1102:31: 0x1224ec1 in decode__anon_41434 (protobuf.zig)
    _ = try wire.decodeMessage(&result, allocator, reader, .{});
                              ^
```
</details>