### PR TITLE
fix(dupe): use allocator.dupe for repeated scalar string/bytes fields

### DIFF
--- a/src/protobuf.zig
+++ b/src/protobuf.zig
@@ -719,7 +719,7 @@ fn dupeField(
                 .scalar => |scalar| switch (scalar) {
                     .string, .bytes => {
                         for (@field(original, field_name).items) |item| {
-                            try list.append(allocator, try item.dupe(allocator));
+                            try list.append(allocator, try allocator.dupe(u8, item));
                         }
                     },
                     else => {

--- a/tests/leaks.zig
+++ b/tests/leaks.zig
@@ -25,6 +25,22 @@ test "leak in allocated string" {
     try testing.expectEqualSlices(u8, "asd", demo.field.?.field);
 }
 
+test "dupe: repeated scalar bytes" {
+    var my_bytes: std.ArrayList([]const u8) = try .initCapacity(testing.allocator, 2);
+    try my_bytes.append(testing.allocator, try testing.allocator.dupe(u8, "hello"));
+    try my_bytes.append(testing.allocator, try testing.allocator.dupe(u8, "world"));
+
+    var msg: tests.WithRepeatedBytes = .{ .byte_field = my_bytes };
+    defer msg.deinit(testing.allocator);
+
+    var copy = try msg.dupe(testing.allocator);
+    defer copy.deinit(testing.allocator);
+
+    try testing.expectEqual(msg.byte_field.items.len, copy.byte_field.items.len);
+    try testing.expectEqualSlices(u8, msg.byte_field.items[0], copy.byte_field.items[0]);
+    try testing.expectEqualSlices(u8, msg.byte_field.items[1], copy.byte_field.items[1]);
+}
+
 test "leak in list of allocated bytes" {
     var my_bytes: std.ArrayList([]const u8) = try .initCapacity(testing.allocator, 1);
     try my_bytes.append(std.testing.allocator, try std.testing.allocator.dupe(u8, "abcdef"));


### PR DESCRIPTION
Items in a `repeated` field with scalar types of `.string` or `.bytes` have no `.dupe` method. This would fail to compile for any message containing repeated sting or repeated bytes field if `.dupe()` was called. This commit fixes this bug by using `allocator.dupe` instead.

I've also added tests that would have failed to compile just as described above if the fix were not applied.