### PR TITLE
Simplify public facing compiler API, enable custom protoc executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,9 @@ pub fn build(b: *std.Build) !void {
     const protoc_step = protobuf.RunProtocStep.create(protobuf_dep.builder, target, .{
         // out directory for the generated zig files
         .destination_directory = b.path("src/proto"),
-        // Optional custom generator, otherwise it will use the built-in generator + google's protoc
-        // .generator = protobuf_dep.artifact("protoc-gen-zig"),
+        // Optional LazyPath to `protoc`. If null, zig-protobuf will download Google's release of
+        // the compiler.
+        // .protoc = b.path("protoc"),
         .source_files = &.{
             b.path("protocol/all.proto"),
         },

--- a/build.zig
+++ b/build.zig
@@ -152,9 +152,11 @@ pub fn build(b: *std.Build) !void {
         .destination_directory = b.path("tests/generated"),
         .source_files = &.{
             b.path("tests/protos_for_test/all.proto"),
-            b.path("tests/protos_for_test/whitespace-in-name.proto"),
             b.path("tests/protos_for_test/complex_type.proto"),
+            b.path("tests/protos_for_test/issue-143-self-ref-union.proto"),
+            b.path("tests/protos_for_test/onnx.proto"),
             b.path("tests/protos_for_test/test_service.proto"),
+            b.path("tests/protos_for_test/whitespace-in-name.proto"),
         },
         .include_directories = &.{b.path("tests/protos_for_test")},
     });

--- a/build_util.zig
+++ b/build_util.zig
@@ -79,10 +79,7 @@ pub const RunProtocStep = struct {
     include_directories: []std.Build.LazyPath,
     destination_directory: std.Build.LazyPath,
     generator: *std.Build.Step.Compile,
-    /// Optional external protoc binary. When set, skips the built-in download
-    /// mechanism and uses this artifact's emitted binary instead. Useful for
-    /// consumers (e.g. conformance tests) that already have protoc from another
-    /// dependency.
+    generator_bin: std.Build.LazyPath,
     protoc_override_bin: ?std.Build.LazyPath = null,
     preserve_unknown_fields: bool = false,
     verbose: bool = false,
@@ -127,6 +124,7 @@ pub const RunProtocStep = struct {
             .include_directories = dupeLazyPaths(owner, options.include_directories),
             .destination_directory = options.destination_directory.dupe(owner),
             .generator = generator,
+            .generator_bin = generator.getEmittedBin(),
             .protoc_override_bin = options.protoc,
             .preserve_unknown_fields = options.preserve_unknown_fields,
         };
@@ -174,7 +172,7 @@ pub const RunProtocStep = struct {
 
                 try argv.append(b.allocator, try std.mem.concat(b.allocator, u8, &.{
                     "--plugin=protoc-gen-zig=",
-                    self.generator.getEmittedBin().getPath2(b, step),
+                    self.generator_bin.getPath2(b, step),
                 }));
 
                 const zig_out = if (self.preserve_unknown_fields)

--- a/build_util.zig
+++ b/build_util.zig
@@ -79,12 +79,11 @@ pub const RunProtocStep = struct {
     include_directories: []std.Build.LazyPath,
     destination_directory: std.Build.LazyPath,
     generator: *std.Build.Step.Compile,
-    protoc_owner: *std.Build,
     /// Optional external protoc binary. When set, skips the built-in download
     /// mechanism and uses this artifact's emitted binary instead. Useful for
     /// consumers (e.g. conformance tests) that already have protoc from another
     /// dependency.
-    protoc_override: ?*std.Build.Step.Compile = null,
+    protoc_override_bin: ?std.Build.LazyPath = null,
     preserve_unknown_fields: bool = false,
     verbose: bool = false,
 
@@ -98,9 +97,9 @@ pub const RunProtocStep = struct {
         /// protoc step can be owned by a consumer builder while the generator
         /// stays owned by the zig-protobuf dependency builder.
         generator: ?*std.Build.Step.Compile = null,
-        /// Optional pre-built protoc artifact. When provided, overrides the
+        /// Optional pre-built protoc binary. When provided, overrides the
         /// built-in protoc download mechanism.
-        protoc: ?*std.Build.Step.Compile = null,
+        protoc: ?std.Build.LazyPath = null,
         /// When true, every generated message preserves unknown fields during
         /// binary decode/encode round trips. Defaults to false.
         preserve_unknown_fields: bool = false,
@@ -128,13 +127,12 @@ pub const RunProtocStep = struct {
             .include_directories = dupeLazyPaths(owner, options.include_directories),
             .destination_directory = options.destination_directory.dupe(owner),
             .generator = generator,
-            .protoc_owner = generator.step.owner,
-            .protoc_override = options.protoc,
+            .protoc_override_bin = options.protoc,
             .preserve_unknown_fields = options.preserve_unknown_fields,
         };
 
         self.step.dependOn(&self.generator.step);
-        if (options.protoc) |p| self.step.dependOn(&p.step);
+
         return self;
     }
 
@@ -166,10 +164,10 @@ pub const RunProtocStep = struct {
         { // run protoc
             var argv: std.ArrayList([]const u8) = .empty;
 
-            const maybe_protoc_path: ?[]const u8 = if (self.protoc_override) |p|
-                p.getEmittedBin().getPath2(b, step)
+            const maybe_protoc_path: ?[]const u8 = if (self.protoc_override_bin) |bin|
+                bin.getPath2(b, step)
             else
-                try ensureProtocBinaryDownloaded(self.protoc_owner, step);
+                try ensureProtocBinaryDownloaded(self.generator.step.owner, step);
 
             if (maybe_protoc_path) |protoc_path| {
                 try argv.append(b.allocator, protoc_path);

--- a/conformance/build.zig
+++ b/conformance/build.zig
@@ -24,9 +24,13 @@ pub fn build(b: *std.Build) void {
         .include_directories = &.{ b.path("protos"), upstream.path("src") },
         .destination_directory = b.path("generated"),
         .generator = protoc_gen_zig,
-        .protoc = protoc,
+        .protoc = protoc.getEmittedBin(),
         .preserve_unknown_fields = true,
     });
+
+    // Instruct zig build system to first build protoc before trying to generate the .pb.zig!
+    gen_zig.step.dependOn(&protoc.step);
+
     b.step("generate", "Regenerate Zig bindings for conformance protos").dependOn(&gen_zig.step);
 
     // Testee binary — uses pre-generated bindings from conformance/generated/.


### PR DESCRIPTION
Simplifies and fixes the public facing API for build.zig, we were using a wrong owner and that broke the README example.

Hardly used fields were removed in favor of passing `LazyPath("protoc")` which I consider more useful for people that 1) do not want to use google's 2) there are no prebuilt binaries (BSD)

I think this PR can also be enough to close https://github.com/Arwalk/zig-protobuf/pull/173