### PR TITLE
WIP: build: use protobuf port instead of downloading binaries

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -177,7 +177,8 @@ pub fn build(b: *std.Build) !void {
         test_step.dependOn(&run_main_tests.step);
     }
 
-    const include = if (try build_util.getProtocDependency(b)) |protoc| protoc.path("include") else b.path("");
+    const protobuf_dep = b.dependency("protobuf", .{});
+    const include = protobuf_dep.artifact("libprotobuf").getEmittedIncludeTree();
 
     const bootstrap = b.step("bootstrap", "run the generator over its own sources");
 
@@ -187,7 +188,9 @@ pub fn build(b: *std.Build) !void {
             include.path(b, "google/protobuf/compiler/plugin.proto"),
             include.path(b, "google/protobuf/descriptor.proto"),
         },
-        .include_directories = &.{},
+        .include_directories = &.{
+            include,
+        },
     });
 
     bootstrap.dependOn(&bootstrapConversion.step);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -7,45 +7,9 @@
     .minimum_zig_version = "0.16.0",
 
     .dependencies = .{
-        .@"protoc-linux-64" = .{
-            .url = "https://github.com/protocolbuffers/protobuf/releases/download/v32.1/protoc-32.1-win64.zip",
-            .hash = "N-V-__8AAAOIwgCuuT3IhPlAW6erD8SspcE7iVKY4nbJWLV6",
-            .lazy = true,
-        },
-        .@"protoc-linux-x86_64" = .{
-            .url = "https://github.com/protocolbuffers/protobuf/releases/download/v32.1/protoc-32.1-linux-x86_64.zip",
-            .hash = "N-V-__8AAGKbngAmNuaBMSXq_WgmQi6N8WVWVKp0moFSTvoJ",
-            .lazy = true,
-        },
-        .@"protoc-linux-x86_32" = .{
-            .url = "https://github.com/protocolbuffers/protobuf/releases/download/v32.1/protoc-32.1-linux-x86_32.zip",
-            .hash = "N-V-__8AAHpvrAAEcEurDCWYQt6jTJSozCfLDwkGTptKEyJ7",
-            .lazy = true,
-        },
-        .@"protoc-linux-aarch_64" = .{
-            .url = "https://github.com/protocolbuffers/protobuf/releases/download/v32.1/protoc-32.1-linux-aarch_64.zip",
-            .hash = "N-V-__8AAJKMngA8y82sENkRg-JF100BtRa7GQxoBIfU3c3_",
-            .lazy = true,
-        },
-        .@"protoc-osx-aarch_64" = .{
-            .url = "https://github.com/protocolbuffers/protobuf/releases/download/v32.1/protoc-32.1-osx-aarch_64.zip",
-            .hash = "N-V-__8AANrukAA2AHP6xuzchs_iwsyg1UYhIFhpUR6R0x7K",
-            .lazy = true,
-        },
-        .@"protoc-osx-x86_64" = .{
-            .url = "https://github.com/protocolbuffers/protobuf/releases/download/v32.1/protoc-32.1-osx-x86_64.zip",
-            .hash = "N-V-__8AAFoXkgBrHnNjViSdp84aL1ciwtWKZdYHK7dSSppd",
-            .lazy = true,
-        },
-        .@"protoc-win64" = .{
-            .url = "https://github.com/protocolbuffers/protobuf/releases/download/v32.1/protoc-32.1-win64.zip",
-            .hash = "N-V-__8AAAOIwgCuuT3IhPlAW6erD8SspcE7iVKY4nbJWLV6",
-            .lazy = true,
-        },
-        .@"protoc-linux-s390" = .{
-            .url = "https://github.com/protocolbuffers/protobuf/releases/download/v32.1/protoc-32.1-linux-s390_64.zip",
-            .hash = "N-V-__8AADKo3ADb6qHynR1iiBhHFQcaoAE0qpLZuh3GtoT2",
-            .lazy = true,
+        .protobuf = .{
+            .url = "git+https://github.com/allyourcodebase/protobuf#129e9190ffd3e67ade0eb0abdff3b94c08261dae",
+            .hash = "protobuf-35.1.0-BF8X-S1fAAD-sXN409wws8ZhXWxkJ1TcaAa7vV8EYZ0-",
         },
     },
     .paths = .{

--- a/build_util.zig
+++ b/build_util.zig
@@ -129,6 +129,10 @@ pub const RunProtocStep = struct {
             .preserve_unknown_fields = options.preserve_unknown_fields,
         };
 
+        const protobuf_dep = owner.dependency("protobuf", .{});
+        const protoc = protobuf_dep.artifact("protoc");
+
+        self.step.dependOn(&protoc.step);
         self.step.dependOn(&self.generator.step);
 
         return self;
@@ -159,13 +163,13 @@ pub const RunProtocStep = struct {
 
         const absolute_dest_dir = self.destination_directory.getPath2(b, step);
 
+        const protobuf_dep = b.dependency("protobuf", .{});
+        const protoc = protobuf_dep.artifact("protoc");
+
         { // run protoc
             var argv: std.ArrayList([]const u8) = .empty;
 
-            const maybe_protoc_path: ?[]const u8 = if (self.protoc_override_bin) |bin|
-                bin.getPath2(b, step)
-            else
-                try ensureProtocBinaryDownloaded(self.generator.step.owner, step);
+            const maybe_protoc_path: ?[]const u8 = protoc.getEmittedBin().getPath2(b, step);
 
             if (maybe_protoc_path) |protoc_path| {
                 try argv.append(b.allocator, protoc_path);


### PR DESCRIPTION
follow-up to #146

[allyourcodebase/protobuf](https://github.com/allyourcodebase/protobuf) now exists and builds protoc from source, this PR makes use of it for bootstrap but nothing else.

There are a lot of decisions to be made if this path is chosen such as:
- How will the dependency be shared around?
- How will the default include path be added (you already have dupeLazyPaths and might want to write another helper for it)
- etc.
